### PR TITLE
use inline image for dash list decoration

### DIFF
--- a/scss/partials/_statewide-ortho.scss
+++ b/scss/partials/_statewide-ortho.scss
@@ -182,15 +182,9 @@
 }
 
 ul.dash {
-    list-style: none;
+    list-style: square inside url('data:image/gif;base64,R0lGODlhBQAKAIABAAAAAP///yH5BAEAAAEALAAAAAAFAAoAAAIIjI+ZwKwPUQEAOw==');
     margin-left: 0;
     padding-left: 1em;
-}
-ul.dash li:before {
-    display: inline-block;
-    content: "-";
-    width: 1em;
-    margin-left: -1em;
 }
 
 .ortho-top {


### PR DESCRIPTION
this avoids the problem of non-hanging indents and whitespace sensitivity caused by using `:before` content.