### PR TITLE
don't include ':' in form input item; it needs to be escaped when

### DIFF
--- a/templates/partials/google/google-request-form.html
+++ b/templates/partials/google/google-request-form.html
@@ -79,7 +79,7 @@
   )}}
 
   {{form.input(
-    "Anticipated project end date:",
+    "Anticipated project end date",
     {
       label: "Anticipated project end date:",
       placeholder: "Project End Date"


### PR DESCRIPTION
processing the form data and that is kind of annoying