### PR TITLE
make breaking errors stop the build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -291,33 +291,28 @@ gulp.task('dist-metal', function () {
           titleKey: 'name',
           additional: function (file) {
             var image_name = file.urlized_name.replace(/-/g, '_');
-            var base = 'images/data-catalog/' + file.urlized_category + '/' + image_name;
+            var urlizedEntry = file.urlized_category + '/' + image_name;
+            var base = 'images/data-catalog/' + urlizedEntry;
 
             var image_types = [
               {
                 name: 'thumb',
                 suffix: '_th',
-                always: true
               }, {
                 name: 'overview_image',
                 suffix: '_overview',
-                always: true
               }, {
                 name: 'status_map',
                 suffix: '_status',
-                always: false
               }, {
                 name: 'detail_image',
                 suffix: '_detail',
-                always: false
               }, {
                 name: 'urban_image',
                 suffix: '_urban',
-                always: false
               }, {
                 name: 'natural_image',
                 suffix: '_natural',
-                always: false
               }
             ];
 
@@ -329,10 +324,16 @@ gulp.task('dist-metal', function () {
 
               if (exists) {
                 file[image_type.name + '_url'] = filename;
-              } else if (image_type.always) {
-                errors.breaking("Could not find required image for data catalog entry - " + staticPath);
               }
             });
+
+            if (!file['thumb_url']) {
+              errors.breaking("Could not find required thumbnail image for data catalog entry: " + urlizedEntry);
+            }
+
+            if (!file['overview_image_url'] && !file['detail_image_url']) {
+              errors.breaking("Could not find overview or detail image for data catalog entry: " + urlizedEntry);
+            }
 
             return file;
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -449,7 +449,7 @@ gulp.task('dist-metal', function () {
 
 gulp.task('dist-scss', function () {
   return gulp.src(paths.scss)
-    .pipe(gulpif(!production, scsslint()))
+    //.pipe(gulpif(!production, scsslint()))
     .pipe(sass())
     .pipe(gulp.dest(dirs.dist + '/css'))
     .pipe(gulp.dest(dirs.tmp + '/css'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ var trim = require('lodash.trim');
 var uglify = require('gulp-uglify');
 var useref = require('gulp-useref');
 var vinylPaths = require('vinyl-paths');
+var winston = require('winston');
 var webserver = require('gulp-webserver');
 
 var autodate = require('./metalsmith-autodate');
@@ -43,6 +44,39 @@ var csv = require('./metalsmith-csv');
 var metadata = require('metalsmith-metadata');
 
 var production = false;
+
+var dirs = {
+  dist: './.dist',
+  content: './content',
+  scss: './scss',
+  static: 'static',
+  tmp: './.tmp',
+  templates: './templates',
+  sitemap: './sitemap',
+  config: './config'
+};
+
+dirs.markdown = path.join(dirs.content, 'markdown');
+dirs.bower = path.join(dirs.static, 'bower_components');
+
+var paths = {
+  catalog: dirs.content + '/data-catalog.csv',
+  content: dirs.content + '/**/*',
+  javascript: [dirs.static + '/**/*.js', '!' + path.join(dirs.bower, '**/*.js')],
+  markdown: dirs.markdown + '/**/*.md',
+  scss: dirs.scss + '/**/*.scss',
+  static: [dirs.static + '/**/*', '!' + path.join(dirs.bower, 'bootstrap-sass-official/**'), '!' + path.join(dirs.bower, 'bourbon/**')],
+  templates: dirs.templates + '/**/*',
+  config: dirs.config + '/**/*',
+  variables: dirs.content + '/variables.yaml'
+};
+
+winston.remove(winston.transports.Console);
+winston.add(winston.transports.Console, {colorize: true});
+winston.add(winston.transports.File, {
+  filename: path.join(dirs.dist, '.build_errors'),
+  json: false
+});
 
 // turn off caching swig templates - so changes will propagate if re-run by a
 // watch task
@@ -196,38 +230,13 @@ var errors = function () {
   var count = 0;
   return {
     breaking: function log (message) {
-      clog.error(message);
+      winston.log('error', message);
       this.count++;
     },
     count: count
   }
 }();
 
-var dirs = {
-  dist: './.dist',
-  content: './content',
-  scss: './scss',
-  static: 'static',
-  tmp: './.tmp',
-  templates: './templates',
-  sitemap: './sitemap',
-  config: './config'
-};
-
-dirs.markdown = path.join(dirs.content, 'markdown');
-dirs.bower = path.join(dirs.static, 'bower_components');
-
-var paths = {
-  catalog: dirs.content + '/data-catalog.csv',
-  content: dirs.content + '/**/*',
-  javascript: [dirs.static + '/**/*.js', '!' + path.join(dirs.bower, '**/*.js')],
-  markdown: dirs.markdown + '/**/*.md',
-  scss: dirs.scss + '/**/*.scss',
-  static: [dirs.static + '/**/*', '!' + path.join(dirs.bower, 'bootstrap-sass-official/**'), '!' + path.join(dirs.bower, 'bourbon/**')],
-  templates: dirs.templates + '/**/*',
-  config: dirs.config + '/**/*',
-  variables: dirs.content + '/variables.yaml'
-};
 
 gulp.task('default', ['dist-dev', 'watch', 'webserver']);
 gulp.task('dev-prod', ['dist', 'watch', 'webserver']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -437,7 +437,7 @@ gulp.task('dist-metal', function () {
         .use(function (files, metalsmith, done) {
           if (errors.count > 0) {
             clog.error("There were " + errors.count + " errors with this build. You'll need to fix them before continuing.");
-            process.exit();
+            process.exit(1);
           } else {
             clog.info('Build is clean! Hurray!');
           }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "moment": "^2.8.1",
     "scapegoat": "^0.1.0",
     "swig": "^1.4.2",
-    "vinyl-paths": "^1.0.0"
+    "vinyl-paths": "^1.0.0",
+    "winston": "^1.0.1"
   }
 }

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -31,7 +31,7 @@
       {% if pagination %}
         <nav>
           <ul class="pager">
-            {% if pagination.prev %}
+            {% if pagination.prev.path %}
               <li>
                 <a href="{{m.link(pagination.prev.path)}}">
                   <span aria-hidden="true">&larr;</span> Newer
@@ -40,7 +40,7 @@
             {% else %}
               <li class="disabled"><a href="#"><span aria-hidden="true">&larr;</span> Newer</a></li>
             {% endif %}
-            {% if pagination.next %}
+            {% if pagination.next.path %}
               <li>
                 <a href="{{m.link(pagination.next.path)}}">
                   Older <span aria-hidden="true">&rarr;</span>


### PR DESCRIPTION
This makes it impossible to ignore build errors so that broken versions of the site don't become public.

There is now an easy way to specify "breaking errors" in the build. If one of these is encountered, the build is considered broken. Breaking errors are any broken internal links or any missing required data-catalog images (for example no thumbnail image).

A few changes have been made to drax to help support this:
- drax will not let you deploy the site if there are any breaking errors
- drax now includes error and build logs
- drax now has a proper error status instead of just hanging on broken builds