### PR TITLE
Star forum talks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "angular-recaptcha": "~2.2.1",
     "ng-file-upload": "~3.3.4",
     "leaflet": "~0.7.3",
-    "leaflet-plugins": "~1.3.3"
+    "leaflet-plugins": "~1.3.3",
+    "jquery.storage": "~0.0.3"
   },
   "resolutions": {
     "angular": "1.3.5"

--- a/content/markdown/2015-gis-forum.md
+++ b/content/markdown/2015-gis-forum.md
@@ -88,25 +88,21 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
 </div>
 <hr>
 <h2>2015 FORUM AGENDA</h2>
-<p class="lead-forum">
-   Note: Agenda and speakers subject to change without notice
-</p>
-
-<div class="container">
-<div class="row well well-sm personalize-agenda">
-
-<div class="col-sm-5">
-  <div class="checkbox">
-  <label>
-  <input type="checkbox"> Only Show My Starred Presentations
-  </label>
+<div class="row">
+  <div class="well well-sm personalize-agenda col-sm-7">
+    <div class="checkbox">
+      <label>
+      <input type="checkbox"> Only Show My Starred Presentations
+      </label>
+      </div>
+    <p><strong>Personalize your agenda</strong> by selecting the star <i class="glyphicon glyphicon-star"></i> next to the presentation/s you want to highlight.</p>
+    <p></p>
   </div>
-</div>
-<div class="col-sm-7">
-  <h4>Personalize Your Agenda</h4>
-  Select the star <i class="glyphicon glyphicon-star"></i> next to the presentations you want to highlight.
-</div>
-</div>
+  <div class="col-sm-5">
+  <p class="lead-forum">
+     Note: Agenda and speakers subject to change without notice
+  </p>
+  </div>
 </div>
 
 
@@ -162,10 +158,12 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
           <em>Nicholas Villarreal, Graduate Intern/SMWI Project, Texas State University at San Marcos | Jennifer Jensen, Texas State University at San Marcos and Kristina Tolman, The Meadows Center for Water and the Environment</em>
         </li>
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>Monitoring Change in West TX using NAIP Imagery from the Texas Natural Resources Information System</strong><br>
           <em>Frank Obusek, Hexagon Geospatial</em>
         </li>
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>UAV Solutions Using Remote Sensing and Photogra.m.metry Applications</strong><br>
           <em>Joe Mostowy, Hexagon Geospatial</em>
         </li>
@@ -175,14 +173,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
       <h3><small>Session B (Li'l TEX)</small><br>Applied GIS (Putting GIS to Work)</h3>
       <ul class="agenda-track">
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>Innovative Public Health Care GIS Applications</strong><br>
           <em>Jack Hill and Amanda Scarborough, Sam Houston State University</em>
         </li>
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>Planning and Implementation of Address Point Projects for NG9-1-1: Accurate Data Points for Accurate Call Routing</strong><br>
           <em>Kim Paxton, Intrado</em>
         </li>
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>GIS at the Wimberley Flash Flood Disaster </strong><br>
           <em>Devon Humphrey, Waypoint Mapping</em>
         </li>
@@ -222,14 +223,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <h3><small>Session A (Big Tex)</small><br>Open Source (Something for Everyone)</h3>
     <ul class="agenda-track">
       <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Development of a Binational Geospatial Decision Support System to Protect Water Quality in the Lower Rio Grande: An Innovative Use of Open Source Geographic Information System Software</strong><br>
         <em>Roger Miranda, University of Texas, LBJ School of Public Affairs and Alexander Sun, University of Texas Bureau of Economic Geology | T. Clay Templeton, PhD Student, University of Texas - School of Information</em>
       </li>
       <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>GIS Lessons: Learning to Query and Code with the CartoDB Academy </strong><br>
         <em>Andy Eschbacher, CartoDB</em>
       </li>
       <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Open Source Software Education in Texas</strong><br>
         <em>Phillip Davis, GeoAcademy and Richard Smith, Texas A &amp; M University, Corpus Christi</em>
       </li>
@@ -239,14 +243,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <h3><small>Session B (Li'l TEX)</small><br>Innovative Technology (New to You)</h3>
     <ul class="agenda-track" >
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Augmented Reality for Hidden Assets</strong><br>
         <em>Brady Hustad and Ken Hetlinger, Astadia</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>VOICE - Virtual Online Inspection Checking and Editing</strong><br>
         <em>Anand Iyer, Jeff Simmons, Quantum Spacial</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Integrating Autocad and GIS into a Preventative Maintenance Plan for Roadways</strong><br>
         <em>Adrian Garcia and Ernie Martinez, The City of Fair Oaks Ranch, Texas</em>
       </li>
@@ -274,14 +281,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     </h3>
     <ul class="agenda-track">
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>The History of Texas is Under Your Feet and at Your Fingertips</strong><br>
         <em> Daniel K. Pearson, US Geological Survey</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>The Texas Water Integrated Information Delivery (WIID) 2.0</strong><br>
         <em>Ginny Vragel, Texas Water Development Board | Richard Winkelbauer</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Hosting Spatial Web Services in Support of Oil &amp; Gas Analytics: ArcGIS  Server, WMS &amp; WFS Cross-Platform Compatibility</strong><br>
         <em>Dale Emrich, Justin Scott Winn, Cole Howard, DrillingInfo</em>
       </li>
@@ -294,10 +304,12 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     </h3>
     <ul class="agenda-track">
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Google's Imagery Program</strong><br>
         <em>Kyle Campbell, Google | Richard Wade, TNRIS</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>TxCoasts.com: Updating and Re-imaging the Texas Beach &amp; Bay Access Guide</strong><br>
         <em>Laura Wisdom, General Land Office</em>
       </li>
@@ -361,14 +373,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <h3><small>Session A (Big Tex)</small><br>Lidar (Get to the Points)</h3>
     <ul class="agenda-track">
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Change Detection on the Llano Estacado: Lidar and Image Point Cloud modeling in Support of Building Update Collection</strong><br>
         <em>Robert Dzur, Bohannan Huston, Inc | Sally Abbe, City of Lubbock</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Geiger Mode Lidar: The Leap from Single Pulse to Avalanche and What it means to the End User</strong><br>
         <em>Harold Rempel, ESP Associates</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Innovations - Changing the way Lidar is Used</strong><br>
         <em>Jamie Young, Merrick &amp; Company</em>
       </li>
@@ -378,14 +393,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <h3><small>Session B (Li'l TEX)</small><br>Online Map Applications (Apps in the Cloud)</h3>
     <ul class="agenda-track">
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Regional Online Geospatial Services for the Houston-Galveston Region</strong><br>
         <em>Bill Bass, Houston-Galveston Area Council of Governments</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>The Information Commons: Cloud-Based GIS</strong><br>
         <em> Santiago Giraldo Anduaga, CartoDB</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Modern Web Mapping for Local Governments Delivers Insights into Performance Metrics, Patterns of Change &amp; Distribution of Resources</strong><br>
         <em>Kate Hickey, AppGeo</em>
       </li>
@@ -422,14 +440,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <h3><small>Session A (Big Tex)</small><br>Applied GIS (Putting GIS to Work)</h3>
     <ul class="agenda-track">
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>3D Modeling of the City of Temple Landfill</strong><br>
         <em>Leah Fasick, City of Temple</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Examination of the spatial relationship between development and aquatic nutrient loading in the Galveston Bay Estuary</strong><br>
         <em> Helen Walters and Samuel Brody, Texas A&amp;M University, Galveston Campus</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>The GCCPRD Storm Surge Suppression Study of the Upper Texas Coast</strong><br>
         <em> Jeff Scarborough and Chris Sallese, Dannenbaum Engineering Corporation</em>
       </li>
@@ -440,10 +461,13 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
 
     <h3><small>Session B (Li'l TEX)</small><br>Lo-GIS-tics (Keeping Track)</h3>
      <ul class="agenda-track" >
-      <li><strong>Connecting the Dots Between Data and Problem Solving,</strong><br>
+      <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
+        <strong>Connecting the Dots Between Data and Problem Solving,</strong><br>
         <em>Leah Casey, Texas Department of Health and Human Services and Jeff Jordan, Institute for Demographic Studies and Socioeconomic Research</em>
       </li>
       <li>
+        <button><i class="glyphicon glyphicon-star"></i></button>
         <strong>Managing Special Events in Austin, TX with ArcGIS Online</strong><br>
         <em>Jacquie Hrncir and John Clary, City of Austin</em>
       </li>

--- a/content/markdown/2015-gis-forum.md
+++ b/content/markdown/2015-gis-forum.md
@@ -13,77 +13,76 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
 ---
 <div class="row">
   <div class="col-sm-5">
-<p class="lead-forum">
-  For nearly 3 decades, the Texas GIS Forum has been the can't-miss event for the statewide GIS community. Come to Austin this fall to hear about the latest advancements in the private and public sector, and an opportunity to touch base with long-time colleagues – as well as make new connections.
-</p>
-</div>
-<div class="col-sm-7 registration-box">
-  <h3>Registration Fees</h3>
-    <table class="table">
-      <tr>
-        <th></th>
-        <th>Before Sept. 25</th>
-        <th>Sept. 26 - Oct. 16</th>
-        <th>Onsite</th>
-        <th>One Day</th>
-      </tr>
-      <tr>
-        <td><strong>Government</strong></td>
-        <td>$275 (2 for 1)</td>
-        <td>$275</td>
-        <td>$300</td>
-        <td>$185</td>
-      </tr>
-      <tr>
-        <td><strong>Industry</strong></td>
-        <td>$300</td>
-        <td>$325</td>
-        <td>$350</td>
-        <td>$200</td>
-      </tr>
-      <tr>
-        <td><strong> Student</strong></td>
-        <td>$50</td>
-        <td>$50</td>
-        <td>$50</td>
-        <td>$25</td>
-      </tr>
-    </table>
-    <small> NOTE: Those registering as a "Student" MUST present a valid student I.D. upon registration check-in.</small>
-</div>
+    <p class="lead-forum">
+      For nearly 3 decades, the Texas GIS Forum has been the can't-miss event for the statewide GIS community. Come to Austin this fall to hear about the latest advancements in the private and public sector, and an opportunity to touch base with long-time colleagues – as well as make new connections.
+    </p>
+  </div>
+  <div class="col-sm-7 registration-box">
+    <h3>Registration Fees</h3>
+      <table class="table">
+        <tr>
+          <th></th>
+          <th>Before Sept. 25</th>
+          <th>Sept. 26 - Oct. 16</th>
+          <th>Onsite</th>
+          <th>One Day</th>
+        </tr>
+        <tr>
+          <td><strong>Government</strong></td>
+          <td>$275 (2 for 1)</td>
+          <td>$275</td>
+          <td>$300</td>
+          <td>$185</td>
+        </tr>
+        <tr>
+          <td><strong>Industry</strong></td>
+          <td>$300</td>
+          <td>$325</td>
+          <td>$350</td>
+          <td>$200</td>
+        </tr>
+        <tr>
+          <td><strong> Student</strong></td>
+          <td>$50</td>
+          <td>$50</td>
+          <td>$50</td>
+          <td>$25</td>
+        </tr>
+      </table>
+      <small> NOTE: Those registering as a "Student" MUST present a valid student I.D. upon registration check-in.</small>
+  </div>
 </div>
 <hr>
 <div class="row">
-<div class="col-sm-7">
-<h3>Bringing the Best, Not Just In GIS</h3>
-
-<p class="lead-forum">The Forum has made a name for itself by bringing top-tier speakers to keynote the conference. In addition to those at the top of the GIS field, we have hosted astronauts, TV personalities, reknowned historians, and more.
-</p>
-<p class="lead-forum">
-  This year continues that record of exciting thinkers with Digital Humanitarian, <a href="#keynote-meier">Patrick Meier</a>, UCGIS Fellow, <a href="#keynote-cowen')}}">David Cowen</a>, and Aerospace Engineer, <a href="#keynote-humphreys">Todd Humphreys</a>.
-</p>
-</div>
-<div class="col-sm-5">
-  <div class="row keynote-feature">
-    <div class="col-xs-4">
-      <a class="smooth-scroll" href="#keynote-meier">
-      <img alt="Patrick Meier Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/patrick_square.jpg')}}">
-      <h3><small>Digital Humanitarian</small><br>Patrick <br class="hidden-xs">Meier</h3>
-      </a>
-    </div>
-    <div class="col-xs-4">
-    <a class="smooth-scroll" href="#keynote-cowen">
-  <img alt="David Cowen Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/cowen_square.jpg')}}">
-  <h3><small>UCGIS Fellow</small><br>David <br class="hidden-xs">Cowen</h>
-    </a>
-    </div>
-    <div class="col-xs-4">
-    <a class="smooth-scroll" href="#keynote-humphreys">
-  <img alt="Todd Humphreys Small Headshot"  class="img-responsive img-circle" src="{{m.link('static/images/front-page/humphreys_square.jpg')}}">
-      <h3><small>UT Professor</small><br>Todd <br class="hidden-xs">Humphreys</h3>
-    </a>
-    </div>
+  <div class="col-sm-7">
+    <h3>Bringing the Best, Not Just In GIS</h3>
+    <p class="lead-forum">The Forum has made a name for itself by bringing top-tier speakers to keynote the conference. In addition to those at the top of the GIS field, we have hosted astronauts, TV personalities, reknowned historians, and more.
+    </p>
+    <p class="lead-forum">
+      This year continues that record of exciting thinkers with Digital Humanitarian, <a href="#keynote-meier">Patrick Meier</a>, UCGIS Fellow, <a href="#keynote-cowen')}}">David Cowen</a>, and Aerospace Engineer, <a href="#keynote-humphreys">Todd Humphreys</a>.
+    </p>
   </div>
+  <div class="col-sm-5">
+    <div class="row keynote-feature">
+      <div class="col-xs-4">
+        <a class="smooth-scroll" href="#keynote-meier">
+          <img alt="Patrick Meier Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/patrick_square.jpg')}}">
+          <h3><small>Digital Humanitarian</small><br>Patrick <br class="hidden-xs">Meier</h3>
+        </a>
+      </div>
+      <div class="col-xs-4">
+        <a class="smooth-scroll" href="#keynote-cowen">
+          <img alt="David Cowen Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/cowen_square.jpg')}}">
+          <h3><small>UCGIS Fellow</small><br>David <br class="hidden-xs">Cowen</h>
+        </a>
+      </div>
+      <div class="col-xs-4">
+        <a class="smooth-scroll" href="#keynote-humphreys">
+          <img alt="Todd Humphreys Small Headshot"  class="img-responsive img-circle" src="{{m.link('static/images/front-page/humphreys_square.jpg')}}">
+        <h3><small>UT Professor</small><br>Todd <br class="hidden-xs">Humphreys</h3>
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 <hr>
@@ -92,19 +91,17 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
   <div class="well well-sm personalize-agenda col-sm-7">
     <div class="checkbox">
       <label>
-      <input type="checkbox"> Only Show My Starred Presentations
+        <input class="show-starred-check" type="checkbox"> Only Show My Starred Presentations
       </label>
-      </div>
-    <p><strong>Personalize your agenda</strong> by selecting the star <i class="glyphicon glyphicon-star"></i> next to the presentation/s you want to highlight.</p>
-    <p></p>
+    </div>
+    <p><strong>Personalize your agenda</strong> by clicking the star <i class="glyphicon glyphicon-star"></i> next to the presentation/s you want to highlight.</p>
   </div>
   <div class="col-sm-5">
-  <p class="lead-forum">
-     Note: Agenda and speakers subject to change without notice
-  </p>
+    <p class="lead-forum">
+      Note: Agenda and speakers subject to change without notice
+    </p>
   </div>
 </div>
-
 
 <div class="container agenda-full">
   <div class="row">
@@ -152,18 +149,18 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <div class="col-sm-9 col-md-5">
       <h3><small>Session A (Big Tex)</small><br>Remote Sensing (I Spy From Up High)</h3>
       <ul class="agenda-track">
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <li id="one-A-1030-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>Assessing The Utility Of Pixel-based And Object-based Classification Methods For Surveying Wetland Vegetation With An Unmanned Aerial System</strong><br>
           <em>Nicholas Villarreal, Graduate Intern/SMWI Project, Texas State University at San Marcos | Jennifer Jensen, Texas State University at San Marcos and Kristina Tolman, The Meadows Center for Water and the Environment</em>
         </li>
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <li id="one-A-1030-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>Monitoring Change in West TX using NAIP Imagery from the Texas Natural Resources Information System</strong><br>
           <em>Frank Obusek, Hexagon Geospatial</em>
         </li>
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <liid="one-A-1030-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>UAV Solutions Using Remote Sensing and Photogra.m.metry Applications</strong><br>
           <em>Joe Mostowy, Hexagon Geospatial</em>
         </li>
@@ -172,18 +169,18 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
       <h3><small>Session B (Li'l TEX)</small><br>Applied GIS (Putting GIS to Work)</h3>
       <ul class="agenda-track">
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <li id="one-B-1030-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>Innovative Public Health Care GIS Applications</strong><br>
           <em>Jack Hill and Amanda Scarborough, Sam Houston State University</em>
         </li>
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <li id="one-B-1030-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>Planning and Implementation of Address Point Projects for NG9-1-1: Accurate Data Points for Accurate Call Routing</strong><br>
           <em>Kim Paxton, Intrado</em>
         </li>
-        <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
+        <li id="one-B-1030-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
           <strong>GIS at the Wimberley Flash Flood Disaster </strong><br>
           <em>Devon Humphrey, Waypoint Mapping</em>
         </li>
@@ -215,303 +212,305 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
     </div>
   </div>
 
-<div class="row agenda-bg"> 
-  <div class="col-sm-3 col-md-2 time-block" id="DayOne_1400">
-    2:00 - 3:30 p.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayOne_1400">
+      2:00 - 3:30 p.m.
+    </div>
+    <div class="col-sm-9 col-md-5">
+      <h3><small>Session A (Big Tex)</small><br>Open Source (Something for Everyone)</h3>
+      <ul class="agenda-track">
+        <li id="one-A-1400-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Development of a Binational Geospatial Decision Support System to Protect Water Quality in the Lower Rio Grande: An Innovative Use of Open Source Geographic Information System Software</strong><br>
+          <em>Roger Miranda, University of Texas, LBJ School of Public Affairs and Alexander Sun, University of Texas Bureau of Economic Geology | T. Clay Templeton, PhD Student, University of Texas - School of Information</em>
+        </li>
+        <li id="one-A-1400-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>GIS Lessons: Learning to Query and Code with the CartoDB Academy </strong><br>
+          <em>Andy Eschbacher, CartoDB</em>
+        </li>
+        <li id="one-A-1400-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Open Source Software Education in Texas</strong><br>
+          <em>Phillip Davis, GeoAcademy and Richard Smith, Texas A &amp; M University, Corpus Christi</em>
+        </li>
+      </ul>
+    </div>
+    <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
+      <h3><small>Session B (Li'l TEX)</small><br>Innovative Technology (New to You)</h3>
+      <ul class="agenda-track" >
+        <li id="one-B-1400-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Augmented Reality for Hidden Assets</strong><br>
+          <em>Brady Hustad and Ken Hetlinger, Astadia</em>
+        </li>
+        <li id="one-B-1400-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>VOICE - Virtual Online Inspection Checking and Editing</strong><br>
+          <em>Anand Iyer, Jeff Simmons, Quantum Spacial</em>
+        </li>
+        <li id="one-B-1400-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Integrating Autocad and GIS into a Preventative Maintenance Plan for Roadways</strong><br>
+          <em>Adrian Garcia and Ernie Martinez, The City of Fair Oaks Ranch, Texas</em>
+        </li>
+      </ul>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-5">
-    <h3><small>Session A (Big Tex)</small><br>Open Source (Something for Everyone)</h3>
-    <ul class="agenda-track">
-      <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Development of a Binational Geospatial Decision Support System to Protect Water Quality in the Lower Rio Grande: An Innovative Use of Open Source Geographic Information System Software</strong><br>
-        <em>Roger Miranda, University of Texas, LBJ School of Public Affairs and Alexander Sun, University of Texas Bureau of Economic Geology | T. Clay Templeton, PhD Student, University of Texas - School of Information</em>
-      </li>
-      <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>GIS Lessons: Learning to Query and Code with the CartoDB Academy </strong><br>
-        <em>Andy Eschbacher, CartoDB</em>
-      </li>
-      <li>
-          <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Open Source Software Education in Texas</strong><br>
-        <em>Phillip Davis, GeoAcademy and Richard Smith, Texas A &amp; M University, Corpus Christi</em>
-      </li>
-    </ul>
-  </div>
-  <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
-    <h3><small>Session B (Li'l TEX)</small><br>Innovative Technology (New to You)</h3>
-    <ul class="agenda-track" >
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Augmented Reality for Hidden Assets</strong><br>
-        <em>Brady Hustad and Ken Hetlinger, Astadia</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>VOICE - Virtual Online Inspection Checking and Editing</strong><br>
-        <em>Anand Iyer, Jeff Simmons, Quantum Spacial</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Integrating Autocad and GIS into a Preventative Maintenance Plan for Roadways</strong><br>
-        <em>Adrian Garcia and Ernie Martinez, The City of Fair Oaks Ranch, Texas</em>
-      </li>
-    </ul>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayOne_1530">
-    3:30 - 4:00 p.m.
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayOne_1530">
+      3:30 - 4:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Break &amp; Exhibits</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Break &amp; Exhibits</strong>
-  </div>
-</div>
 
-<div class="row agenda-bg">
-  <div class="col-sm-3 col-md-2 time-block" id="DayOne_1600">
-    4:00 - 5:30 p.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayOne_1600">
+      4:00 - 5:30 p.m.
+    </div>
+    <div class="col-sm-9 col-md-5">
+      <h3>
+        <small>Session A (Big Tex)</small><br>
+        Online Map Applications (You Can Do THAT On the Web?)
+      </h3>
+      <ul class="agenda-track">
+        <li id="one-A-1600-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>The History of Texas is Under Your Feet and at Your Fingertips</strong><br>
+          <em> Daniel K. Pearson, US Geological Survey</em>
+        </li>
+        <li id="one-A-1600-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>The Texas Water Integrated Information Delivery (WIID) 2.0</strong><br>
+          <em>Ginny Vragel, Texas Water Development Board | Richard Winkelbauer</em>
+        </li>
+        <li id="one-A-1600-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Hosting Spatial Web Services in Support of Oil &amp; Gas Analytics: ArcGIS  Server, WMS &amp; WFS Cross-Platform Compatibility</strong><br>
+          <em>Dale Emrich, Justin Scott Winn, Cole Howard, DrillingInfo</em>
+        </li>
+      </ul>
+    </div>
+    <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
+      <h3>
+        <small>Session B (Li'l TEX)</small><br>
+        State Initiatives (Cool Enough for Government Work)
+      </h3>
+      <ul class="agenda-track">
+        <li id="one-B-1600-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Google's Imagery Program</strong><br>
+          <em>Kyle Campbell, Google | Richard Wade, TNRIS</em>
+        </li>
+        <li id="one-B-1600-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>TxCoasts.com: Updating and Re-imaging the Texas Beach &amp; Bay Access Guide</strong><br>
+          <em>Laura Wisdom, General Land Office</em>
+        </li>
+      </ul>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-5">
-    <h3>
-      <small>Session A (Big Tex)</small><br>
-      Online Map Applications (You Can Do THAT On the Web?)
-    </h3>
-    <ul class="agenda-track">
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>The History of Texas is Under Your Feet and at Your Fingertips</strong><br>
-        <em> Daniel K. Pearson, US Geological Survey</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>The Texas Water Integrated Information Delivery (WIID) 2.0</strong><br>
-        <em>Ginny Vragel, Texas Water Development Board | Richard Winkelbauer</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Hosting Spatial Web Services in Support of Oil &amp; Gas Analytics: ArcGIS  Server, WMS &amp; WFS Cross-Platform Compatibility</strong><br>
-        <em>Dale Emrich, Justin Scott Winn, Cole Howard, DrillingInfo</em>
-      </li>
-    </ul>
-  </div>
-  <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
-    <h3>
-      <small>Session B (Li'l TEX)</small><br>
-      State Initiatives (Cool Enough for Government Work)
-    </h3>
-    <ul class="agenda-track">
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Google's Imagery Program</strong><br>
-        <em>Kyle Campbell, Google | Richard Wade, TNRIS</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>TxCoasts.com: Updating and Re-imaging the Texas Beach &amp; Bay Access Guide</strong><br>
-        <em>Laura Wisdom, General Land Office</em>
-      </li>
-    </ul>
-  </div>
-</div>
 
-<div class="row forum-social-2015">
-  <div class="col-sm-3 col-md-2 time-block" id="DayOne_1800">
-    6:00 p.m.
+  <div class="row forum-social-2015">
+    <div class="col-sm-3 col-md-2 time-block" id="DayOne_1800">
+      6:00 p.m.
+    </div>
+    <div class="col-sm-9">
+      <h3>Forum Social</h3>
+    </div>
   </div>
-  <div class="col-sm-9">
-    <h3>Forum Social</h3>
-  </div>
-</div>
 
-<div class="row">
-  <h2>Day 2: Thursday, October 29th</h2>
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0700">
-    7:00 - 8:30 a.m.
+  <div class="row">
+    <h2>Day 2: Thursday, October 29th</h2>
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0700">
+      7:00 - 8:30 a.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Registration</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Registration</strong>
-  </div>
-</div>
 
-<div class="row agenda-bg">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0830">
-    8:30 - 9:00 a.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0830">
+      8:30 - 9:00 a.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Opening remarks</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Opening remarks</strong>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0900">
-    9:00 - 10:00 a.m.
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_0900">
+      9:00 - 10:00 a.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <h3 id="keynote-cowen"><small>Keynote Presentation</small><br>David Cowen, UCGIS Fellow</h3>
+      <p><img class="pull-right img-circle keynote-portrait" src="{{ m.link('static/images/texas-gis-forum/2015/david_cowen.jpg')}}"> Dr. David Cowen is recognized as a Fellow of the UCGIS in recognition of his sustained and effective contributions to the field of Geographic Information Systems and Science. Professor Cowen’s contributions in the areas of GIS applications, education, research, government service, and commercial development have had a deep and long-lasting impact upon both geography and GIScience, and on the ways in which GIS is viewed by society.</p>
+      <p><i class="glyphicon glyphicon-user"></i> <a href="{{m.link('news/2015-07-16-ucgis-fellow-david-cowen-keynote-forum')}}">Full Bio</a></p>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <h3 id="keynote-cowen"><small>Keynote Presentation</small><br>David Cowen, UCGIS Fellow</h3>
-    <p><img class="pull-right img-circle keynote-portrait" src="{{ m.link('static/images/texas-gis-forum/2015/david_cowen.jpg')}}"> Dr. David Cowen is recognized as a Fellow of the UCGIS in recognition of his sustained and effective contributions to the field of Geographic Information Systems and Science. Professor Cowen’s contributions in the areas of GIS applications, education, research, government service, and commercial development have had a deep and long-lasting impact upon both geography and GIScience, and on the ways in which GIS is viewed by society.</p>
-    <p><i class="glyphicon glyphicon-user"></i> <a href="{{m.link('news/2015-07-16-ucgis-fellow-david-cowen-keynote-forum')}}">Full Bio</a></p>
-  </div>
-</div>
 
-<div class="row agenda-bg">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1000">
-    10:00 - 10:30 a.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1000">
+      10:00 - 10:30 a.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Break &amp; Exhibits</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Break &amp; Exhibits</strong>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1030">
-    10:30 a.m. - 12:00 p.m.
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1030">
+      10:30 a.m. - 12:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-5">
+      <h3><small>Session A (Big Tex)</small><br>Lidar (Get to the Points)</h3>
+      <ul class="agenda-track">
+        <li id="two-A-1030-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Change Detection on the Llano Estacado: Lidar and Image Point Cloud modeling in Support of Building Update Collection</strong><br>
+          <em>Robert Dzur, Bohannan Huston, Inc | Sally Abbe, City of Lubbock</em>
+        </li>
+        <li id="two-A-1030-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Geiger Mode Lidar: The Leap from Single Pulse to Avalanche and What it means to the End User</strong><br>
+          <em>Harold Rempel, ESP Associates</em>
+        </li>
+        <li id="two-A-1030-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Innovations - Changing the way Lidar is Used</strong><br>
+          <em>Jamie Young, Merrick &amp; Company</em>
+        </li>
+      </ul>
+    </div>
+    <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
+      <h3><small>Session B (Li'l TEX)</small><br>Online Map Applications (Apps in the Cloud)</h3>
+      <ul class="agenda-track">
+        <li id="two-B-1030-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Regional Online Geospatial Services for the Houston-Galveston Region</strong><br>
+          <em>Bill Bass, Houston-Galveston Area Council of Governments</em>
+        </li>
+        <li id="two-B-1030-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>The Information Commons: Cloud-Based GIS</strong><br>
+          <em> Santiago Giraldo Anduaga, CartoDB</em>
+        </li>
+        <li id="two-B-1030-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Modern Web Mapping for Local Governments Delivers Insights into Performance Metrics, Patterns of Change &amp; Distribution of Resources</strong><br>
+          <em>Kate Hickey, AppGeo</em>
+        </li>
+      </ul>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-5">
-    <h3><small>Session A (Big Tex)</small><br>Lidar (Get to the Points)</h3>
-    <ul class="agenda-track">
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Change Detection on the Llano Estacado: Lidar and Image Point Cloud modeling in Support of Building Update Collection</strong><br>
-        <em>Robert Dzur, Bohannan Huston, Inc | Sally Abbe, City of Lubbock</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Geiger Mode Lidar: The Leap from Single Pulse to Avalanche and What it means to the End User</strong><br>
-        <em>Harold Rempel, ESP Associates</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Innovations - Changing the way Lidar is Used</strong><br>
-        <em>Jamie Young, Merrick &amp; Company</em>
-      </li>
-    </ul>
-  </div>
-  <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
-    <h3><small>Session B (Li'l TEX)</small><br>Online Map Applications (Apps in the Cloud)</h3>
-    <ul class="agenda-track">
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Regional Online Geospatial Services for the Houston-Galveston Region</strong><br>
-        <em>Bill Bass, Houston-Galveston Area Council of Governments</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>The Information Commons: Cloud-Based GIS</strong><br>
-        <em> Santiago Giraldo Anduaga, CartoDB</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Modern Web Mapping for Local Governments Delivers Insights into Performance Metrics, Patterns of Change &amp; Distribution of Resources</strong><br>
-        <em>Kate Hickey, AppGeo</em>
-      </li>
-    </ul>
-  </div>
-</div>
 
-<div class="row agenda-bg">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1200">
-    12:00 - 1:00 p.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1200">
+      12:00 - 1:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Lunch &amp; Exhibits</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Lunch &amp; Exhibits</strong>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1300">
-    1:00 – 2:00 p.m.
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1300">
+      1:00 – 2:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <h3>
+        <small>Platinum Sponsor Demo</small><br>
+        Esri
+      </h3>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <h3>
-      <small>Platinum Sponsor Demo</small><br>
-      Esri
-    </h3>
-  </div>
-</div>
 
-<div class="row agenda-bg"> 
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1400">
-    2:00 - 3:30 p.m.
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1400">
+      2:00 - 3:30 p.m.
+    </div>
+    <div class="col-sm-9 col-md-5">
+      <h3><small>Session A (Big Tex)</small><br>Applied GIS (Putting GIS to Work)</h3>
+      <ul class="agenda-track">
+        <li id="two-A-1400-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>3D Modeling of the City of Temple Landfill</strong><br>
+          <em>Leah Fasick, City of Temple</em>
+        </li>
+        <li id="two-A-1400-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Examination of the spatial relationship between development and aquatic nutrient loading in the Galveston Bay Estuary</strong><br>
+          <em> Helen Walters and Samuel Brody, Texas A&amp;M University, Galveston Campus</em>
+        </li>
+        <li id="two-A-1400-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>The GCCPRD Storm Surge Suppression Study of the Upper Texas Coast</strong><br>
+          <em> Jeff Scarborough and Chris Sallese, Dannenbaum Engineering Corporation</em>
+        </li>
+      </ul>
+    </div>
+    <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
+      <h3><small>Session B (Li'l TEX)</small><br>Lo-GIS-tics (Keeping Track)</h3>
+       <ul class="agenda-track" >
+        <li id="two-B-1400-a" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Connecting the Dots Between Data and Problem Solving,</strong><br>
+          <em>Leah Casey, Texas Department of Health and Human Services and Jeff Jordan, Institute for Demographic Studies and Socioeconomic Research</em>
+        </li>
+        <li id="two-B-1400-b" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>Managing Special Events in Austin, TX with ArcGIS Online</strong><br>
+          <em>Jacquie Hrncir and John Clary, City of Austin</em>
+        </li>
+        <li id="two-B-1400-c" class="agenda-track-item">
+          <button class="star-btn"><i class="glyphicon glyphicon-star"></i></button>
+          <strong>3 Words to Address the World</strong><br>
+          <em>Tim Williams, What3Words</em>
+        </li>
+      </ul>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-5">
-    <h3><small>Session A (Big Tex)</small><br>Applied GIS (Putting GIS to Work)</h3>
-    <ul class="agenda-track">
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>3D Modeling of the City of Temple Landfill</strong><br>
-        <em>Leah Fasick, City of Temple</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Examination of the spatial relationship between development and aquatic nutrient loading in the Galveston Bay Estuary</strong><br>
-        <em> Helen Walters and Samuel Brody, Texas A&amp;M University, Galveston Campus</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>The GCCPRD Storm Surge Suppression Study of the Upper Texas Coast</strong><br>
-        <em> Jeff Scarborough and Chris Sallese, Dannenbaum Engineering Corporation</em>
-      </li>
-    </ul>
-  </div>
-  <div class="col-sm-9 col-md-5 col-sm-offset-3 col-md-offset-0">
 
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1330">
+      3:30 - 4:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Break &amp; Exhibits</strong>
+    </div>
+  </div>
 
-    <h3><small>Session B (Li'l TEX)</small><br>Lo-GIS-tics (Keeping Track)</h3>
-     <ul class="agenda-track" >
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Connecting the Dots Between Data and Problem Solving,</strong><br>
-        <em>Leah Casey, Texas Department of Health and Human Services and Jeff Jordan, Institute for Demographic Studies and Socioeconomic Research</em>
-      </li>
-      <li>
-        <button><i class="glyphicon glyphicon-star"></i></button>
-        <strong>Managing Special Events in Austin, TX with ArcGIS Online</strong><br>
-        <em>Jacquie Hrncir and John Clary, City of Austin</em>
-      </li>
-        <li><strong>3 Words to Address the World,</strong><br>
-        <em>Tim Williams, What3Words</em>
-      </li>
-    </ul>
+  <div class="row agenda-bg">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1600">
+      4:00 - 5:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <h3 id="keynote-humphreys"><small>Keynote Presentation</small><br>Todd Humphreys, Aerospace Engineer, UT Austin</h3>
+      <p>
+        <img class="pull-right img-circle keynote-portrait" src="{{ m.link('static/images/texas-gis-forum/2015/humphreys_head.jpg')}}">
+        Todd E. Humphreys is an assistant professor in the department of Aerospace
+        Engineering and Engineering Mechanics at the University of Texas at Austin,
+        and Director of the UT Radionavigation Laboratory. He specializes in the
+        application of optimal detection and estimation techniques to problems in
+        satellite navigation, autonomous systems, and signal processing.  His recent
+        focus has been on secure perception for autonomous systems, including
+        navigation, timing, and collision avoidance, and on centimeter-accurate
+        location for the mass market.
+      </p>
+      <p><i class="glyphicon glyphicon-user"></i> <a href="{{m.link('news/2015-08-24-forum-keynote-ut-professor-todd-humphreys/')}}">Full Bio</a></p>
+    </div>
   </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1330">
-    3:30 - 4:00 p.m.
+  <div class="row">
+    <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1700">
+      5:00 p.m.
+    </div>
+    <div class="col-sm-9 col-md-10">
+      <strong>Closing Remarks</strong>
+    </div>
   </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Break &amp; Exhibits</strong>
-  </div>
-</div>
-
-<div class="row agenda-bg">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1600">
-    4:00 - 5:00 p.m.
-  </div>
-  <div class="col-sm-9 col-md-10">
-     <h3 id="keynote-humphreys"><small>Keynote Presentation</small><br>Todd Humphreys, Aerospace Engineer, UT Austin</h3>
-    <p><img class="pull-right img-circle keynote-portrait" src="{{ m.link('static/images/texas-gis-forum/2015/humphreys_head.jpg')}}">  Todd E. Humphreys is an assistant professor in the department of Aerospace
-Engineering and Engineering Mechanics at the University of Texas at Austin,
-and Director of the UT Radionavigation Laboratory. He specializes in the
-application of optimal detection and estimation techniques to problems in
-satellite navigation, autonomous systems, and signal processing.  His recent
-focus has been on secure perception for autonomous systems, including
-navigation, timing, and collision avoidance, and on centimeter-accurate
-location for the mass market.</p>
-
-    <p><i class="glyphicon glyphicon-user"></i> <a href="{{m.link('news/2015-08-24-forum-keynote-ut-professor-todd-humphreys/')}}">Full Bio</a></p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-3 col-md-2 time-block" id="DayTwo_1700">
-    5:00 p.m.
-  </div>
-  <div class="col-sm-9 col-md-10">
-    <strong>Closing Remarks</strong>
-  </div>
-</div>
-</div>
+</div> {# end div.container.agenda-full #}

--- a/content/markdown/2015-gis-forum.md
+++ b/content/markdown/2015-gis-forum.md
@@ -64,28 +64,51 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
 </p>
 </div>
 <div class="col-sm-5">
-          <div class="row keynote-feature">
-            <div class="col-xs-4">
-              <a class="smooth-scroll" href="#keynote-meier">
-              <img alt="Patrick Meier Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/patrick_square.jpg')}}">
-              <h3><small>Digital Humanitarian</small><br>Patrick <br class="hidden-xs">Meier</h3>
-              </a>
-            </div>
-            <div class="col-xs-4">
-            <a class="smooth-scroll" href="#keynote-cowen">
-          <img alt="David Cowen Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/cowen_square.jpg')}}">
-          <h3><small>UCGIS Fellow</small><br>David <br class="hidden-xs">Cowen</h>
-            </a>
-            </div>
-            <div class="col-xs-4">
-            <a class="smooth-scroll" href="#keynote-humphreys">
-          <img alt="Todd Humphreys Small Headshot"  class="img-responsive img-circle" src="{{m.link('static/images/front-page/humphreys_square.jpg')}}">
-              <h3><small>UT Professor</small><br>Todd <br class="hidden-xs">Humphreys</h3>
-            </a>
-            </div>
-          </div>
+  <div class="row keynote-feature">
+    <div class="col-xs-4">
+      <a class="smooth-scroll" href="#keynote-meier">
+      <img alt="Patrick Meier Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/patrick_square.jpg')}}">
+      <h3><small>Digital Humanitarian</small><br>Patrick <br class="hidden-xs">Meier</h3>
+      </a>
+    </div>
+    <div class="col-xs-4">
+    <a class="smooth-scroll" href="#keynote-cowen">
+  <img alt="David Cowen Small Headshot" class="img-responsive img-circle" src="{{m.link('static/images/front-page/cowen_square.jpg')}}">
+  <h3><small>UCGIS Fellow</small><br>David <br class="hidden-xs">Cowen</h>
+    </a>
+    </div>
+    <div class="col-xs-4">
+    <a class="smooth-scroll" href="#keynote-humphreys">
+  <img alt="Todd Humphreys Small Headshot"  class="img-responsive img-circle" src="{{m.link('static/images/front-page/humphreys_square.jpg')}}">
+      <h3><small>UT Professor</small><br>Todd <br class="hidden-xs">Humphreys</h3>
+    </a>
+    </div>
+  </div>
+  </div>
+</div>
+<hr>
+<h2>2015 FORUM AGENDA</h2>
+<p class="lead-forum">
+   Note: Agenda and speakers subject to change without notice
+</p>
+
+<div class="container">
+<div class="row well well-sm personalize-agenda">
+
+<div class="col-sm-5">
+  <div class="checkbox">
+  <label>
+  <input type="checkbox"> Only Show My Starred Presentations
+  </label>
+  </div>
+</div>
+<div class="col-sm-7">
+  <h4>Personalize Your Agenda</h4>
+  Select the star <i class="glyphicon glyphicon-star"></i> next to the presentations you want to highlight.
 </div>
 </div>
+</div>
+
 
 <div class="container agenda-full">
   <div class="row">
@@ -134,6 +157,7 @@ abstract: Save the date for the Texas GIS Forum, the state's premier conference 
       <h3><small>Session A (Big Tex)</small><br>Remote Sensing (I Spy From Up High)</h3>
       <ul class="agenda-track">
         <li>
+          <button><i class="glyphicon glyphicon-star"></i></button>
           <strong>Assessing The Utility Of Pixel-based And Object-based Classification Methods For Surveying Wetland Vegetation With An Unmanned Aerial System</strong><br>
           <em>Nicholas Villarreal, Graduate Intern/SMWI Project, Texas State University at San Marcos | Jennifer Jensen, Texas State University at San Marcos and Kristina Tolman, The Meadows Center for Water and the Environment</em>
         </li>

--- a/scss/partials/_2015-forum.scss
+++ b/scss/partials/_2015-forum.scss
@@ -38,7 +38,7 @@
 
     .forum-course {
     border-bottom: 1px solid $midlightgrey;
-    margin-bottom: 15px; 
+    margin-bottom: 15px;
     padding-bottom: 15px;
 
       &:last-child {
@@ -91,13 +91,13 @@ h2.logo-2015 {
   display: block;
   height: 126px;
   text-indent: -9999px;
-  width: 607px;  
+  width: 607px;
 }
 
 .forum-map {
   background: $forum2015blue;
   color: white;
-  margin-top: 50px; 
+  margin-top: 50px;
 
   h2 {
     color: $midgrey;
@@ -162,7 +162,7 @@ img.keynote-portrait {
 
 ul.agenda-track {
   padding-left: 25px;
-  
+
   li {
     border-bottom: 1px solid $midgrey;
     list-style: none;
@@ -174,9 +174,13 @@ ul.agenda-track {
       margin-bottom: 0;
       padding-bottom: 0;
     }
+
+    &.starred button.star-btn {
+      color: gold;
+    }
   }
-  
-  button {
+
+  button.star-btn {
     background: 0;
     border: 0;
     color: $middarkgrey;
@@ -187,7 +191,7 @@ ul.agenda-track {
 .lead-forum {
   font-size: 16px;
   font-weight: 300;
-  
+
   @media (min-width: $screen-sm) {
     font-size: 21px;
   }
@@ -218,7 +222,7 @@ ul.agenda-track {
     }
 
     img {
-      
+
       &:hover {
         box-shadow: 0 0 3px $forum2015blue;
       }
@@ -253,7 +257,7 @@ ul.agenda-track {
   h4 {
     margin-top: 0;
   }
-  
+
   .checkbox {
     float: left;
     margin-bottom: 20px;
@@ -261,9 +265,9 @@ ul.agenda-track {
     margin-top: 5px;
     width: auto;
 
-  label {
-    font-size: 20px;
-    padding-left: 10px;
-  }
+    label {
+      font-size: 20px;
+      padding-left: 10px;
+    }
   }
 }

--- a/scss/partials/_2015-forum.scss
+++ b/scss/partials/_2015-forum.scss
@@ -244,4 +244,20 @@ ul.agenda-track {
   }
 }
 
+.well.personalize-agenda {
+  background: $bsinfoblue;
 
+  h4 {
+    margin-top: 0;
+  }
+  
+  .checkbox {
+    margin-left: 0;
+    margin-top: 5px;
+
+  label {
+    font-size: 20px;
+    padding-left: 10px;
+  }
+  }
+}

--- a/scss/partials/_2015-forum.scss
+++ b/scss/partials/_2015-forum.scss
@@ -176,12 +176,11 @@ ul.agenda-track {
     }
   }
   
-  li:before {
-    content: "\f130";
-    font-family: FontAwesome;
-    font-size: 20px;
-    margin-left: -25px;
-    padding-right: 10px;
+  button {
+    background: 0;
+    border: 0;
+    color: $middarkgrey;
+    margin-left: -35px;
   }
 }
 
@@ -247,13 +246,20 @@ ul.agenda-track {
 .well.personalize-agenda {
   background: $bsinfoblue;
 
+  p {
+    color: $forum2015blue;
+  }
+
   h4 {
     margin-top: 0;
   }
   
   .checkbox {
-    margin-left: 0;
+    float: left;
+    margin-bottom: 20px;
+    margin-right: 20px;
     margin-top: 5px;
+    width: auto;
 
   label {
     font-size: 20px;

--- a/scss/partials/_variables.scss
+++ b/scss/partials/_variables.scss
@@ -34,6 +34,7 @@ $successhover: #4b8a4b;
 $error: #a94442;
 $infoblue: #5bc0de;
 $bluegreen: #35adac;
+$bsinfoblue: #d9edf7;
 
 $yellowgreen: #a3c541;
 $canary: #fff4c3;

--- a/static/js/2015forum.js
+++ b/static/js/2015forum.js
@@ -82,7 +82,6 @@
     $('.show-starred-check').on('click', function () {
       var $this = $(this);
       var checked = $this.prop('checked');
-      console.log("I'm " + (checked ? " checked" : " not checked"));
 
       if (checked) {
         $('.agenda-track-item:not(.starred)').hide();

--- a/static/js/2015forum.js
+++ b/static/js/2015forum.js
@@ -76,6 +76,9 @@
       }
       else {
         removeStar(agendaTrackItem.id);
+        if ($('.show-starred-check').prop('checked')) {
+          $(agendaTrackItem).hide();
+        }
       }
     });
 

--- a/static/js/2015forum.js
+++ b/static/js/2015forum.js
@@ -1,0 +1,83 @@
+(function goToConferenceTimeBlock(_now) {
+  var now = _now || moment();
+
+  var dayOne = moment('2015-10-28');
+  var dayTwo = moment('2015-10-29');
+
+  var dayPrefix;
+  if (now.isSame(dayOne, 'day')) {
+    dayPrefix = 'DayOne_';
+  } else if (now.isSame(dayTwo, 'day')) {
+    dayPrefix = 'DayTwo_';
+  } else {
+    return; //exit if not a conference day
+  }
+
+  var bestStart;
+  var nowTime = parseInt(now.format('HHmm'), 10);
+  $('.time-block').each(function () {
+    var blockDayStart = $(this).attr('id').split('_');
+    var blockDay = blockDayStart[0];
+    var blockStart = blockDayStart[1];
+    if (blockDay + '_' !== dayPrefix) {
+      //only look at times for current day
+      return;
+    }
+    if (!bestStart) {
+      bestStart = blockStart;
+    }
+    if (nowTime >= parseInt(blockStart, 10)) {
+      bestStart = blockStart;
+    }
+  });
+  window.location.hash = '#' + dayPrefix + bestStart;
+})();
+
+
+(function() {
+  var STORAGE_KEY = 'forum.agenda_stars'
+  if (!$.localStorage(STORAGE_KEY)) {
+    $.localStorage(STORAGE_KEY, {});
+  }
+
+  var setStar = function (id) {
+    var starred = $.localStorage(STORAGE_KEY);
+    starred[id] = true;
+    $.localStorage(STORAGE_KEY, starred);
+  }
+
+  var removeStar = function (id) {
+    var starred = $.localStorage(STORAGE_KEY);
+    delete starred[id];
+    $.localStorage(STORAGE_KEY, starred);
+  }
+
+  $(function loadStars() {
+    var starred = $.localStorage(STORAGE_KEY);
+    if (!starred) { return; }
+
+    $('.agenda-track-item').each(function () {
+      if (starred[this.id]) {
+        $(this).addClass('starred');
+      }
+    })
+
+  });
+
+  $(function attachStarBehavior() {
+    $('button.star-btn').on('click', function () {
+      var agendaTrackItem = $(this).parents('.agenda-track-item')[0];
+      if (!agendaTrackItem) { return; }
+
+      $(agendaTrackItem).toggleClass('starred');
+
+      if ($(agendaTrackItem).hasClass('starred')) {
+        setStar(agendaTrackItem.id);
+      }
+      else {
+        removeStar(agendaTrackItem.id);
+      }
+    });
+  });
+
+})();

--- a/static/js/2015forum.js
+++ b/static/js/2015forum.js
@@ -78,6 +78,19 @@
         removeStar(agendaTrackItem.id);
       }
     });
+
+    $('.show-starred-check').on('click', function () {
+      var $this = $(this);
+      var checked = $this.prop('checked');
+      console.log("I'm " + (checked ? " checked" : " not checked"));
+
+      if (checked) {
+        $('.agenda-track-item:not(.starred)').hide();
+      }
+      else {
+        $('.agenda-track-item').show();
+      }
+    });
   });
 
 })();

--- a/templates/2015-forum-main.html
+++ b/templates/2015-forum-main.html
@@ -15,44 +15,9 @@
   {{form.scripts()}}
 
   <script src="//cdn.jsdelivr.net/momentjs/2.10.6/moment.min.js"></script>
-  <script>
-    (function (_now) {
-      var now = _now || moment();
-
-      var dayOne = moment('2015-10-28');
-      var dayTwo = moment('2015-10-29');
-
-      var dayPrefix;
-      if (now.isSame(dayOne, 'day')) {
-        dayPrefix = 'DayOne_';
-      } else if (now.isSame(dayTwo, 'day')) {
-        dayPrefix = 'DayTwo_';
-      } else {
-        return; //exit if not a conference day 
-      }
-
-      var bestStart;
-      var nowTime = parseInt(now.format('HHmm'), 10);
-      $('.time-block').each(function () {
-        var blockDayStart = $(this).attr('id').split('_');
-        var blockDay = blockDayStart[0];
-        var blockStart = blockDayStart[1];
-        if (blockDay + '_' !== dayPrefix) { 
-          //only look at times for current day
-          return;
-        } 
-        if (!bestStart) {
-          bestStart = blockStart;
-        }
-        if (nowTime >= parseInt(blockStart, 10)) {
-          bestStart = blockStart;
-        }
-      });
-      window.location.hash = '#' + dayPrefix + bestStart;
-    })();
-  </script>
+  <script src="{{m.based('bower_components/jquery.storage/jquery.storage.js')}}"></script>
+  <script src="{{m.based('js/2015forum.js')}}"></script>
 {% endblock scripts %}
-
 
 
 {% block topcontent %}
@@ -63,18 +28,18 @@
         <div class="hidden-sm hidden-xs">
           <img src="{{m.link(mainimage)}}" class="banner img-responsive" alt="Texas GIS Forum Main Image">
         </div>
-        {% endif %} 
+        {% endif %}
         {% if mainimagesm %}
         <div class="hidden-xs hidden-md hidden-lg">
           <img src="{{m.link(mainimagesm)}}" class="banner img-responsive" alt="Texas GIS Forum Main Image">
         </div>
-        {% endif %} 
+        {% endif %}
 
         {% if mainimagexs %}
         <div class="hidden-sm hidden-md hidden-lg">
           <img src="{{m.link(mainimagexs)}}" class="banner img-responsive" alt="Texas GIS Forum Main Image">
         </div>
-        {% endif %} 
+        {% endif %}
       </div>
     </div>
 
@@ -88,7 +53,7 @@
     </div>
 {% endblock topcontent %}
 
-{% block contents %} 
+{% block contents %}
   {% include "./partials/2015-forum/forum-nav-2015.html" %}
   <div class="row">
     <div class="col-md-12">
@@ -101,7 +66,7 @@
   <section class="forum-map">
     <div class="container">
       <div class="row">
-        {% include "./partials/2015-forum/forum-map.html" %}   
+        {% include "./partials/2015-forum/forum-map.html" %}
       </div>
     </div>
   </section>


### PR DESCRIPTION
ref #563

All done. I actually think we should get rid of the checkbox to hide unstarred items. The reasoning is that it hides the context around the starred items, so the user loses the ordering of the talks. Say the middle slot of a series of 3 talks in a room is starred. When the others are hidden, there is no way to know that it was in the middle slot of those 3 talks.

Let me know what you think and if you agree I can pull out the hiding/showing logic and redo the PR. 