### PR TITLE
fix: accidentally turned off breaking build errors when moving catalog

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,7 +225,7 @@ var errors = function () {
   return {
     breaking: function log (message) {
       winston.log('error', message);
-      //this.count++;
+      this.count++;
     },
     count: count
   }


### PR DESCRIPTION
entry urls