### PR TITLE
invert the way warning about dev version of the site works

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -28,7 +28,8 @@ var Clipboard = require('clipboard/dist/clipboard.js');
 
     // Beta/development alert message
     if (window.location.hostname !== 'tnris.org') {
-      $('.beta-alert').removeClass('hide')
+      $('.alert-holder')
+        .html('<div class="alert alert-warning beta-alert text-center"><strong>Warning!</strong> You are currently viewing a development version of the TNRIS website. For the official version, go to <a href="http://tnris.org">http://tnris.org</a>.</div>');
     }
 
     // from http://zenorocha.github.io/clipboard.js/assets/scripts/tooltips.js

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,8 +38,7 @@
               <img class="hidden-xs" src="{{m.link('static/images/texas-gis-forum/2015/promo-thin-banner.jpg')}}" alt="A thin banner for the 2015 Texas GIS Forum"/></a>
           </div> -->
 
-        <div class="alert alert-warning hide beta-alert text-center">
-          <strong>Warning!</strong> You are currently viewing a development version of the TNRIS website. For the official version, go to <a href="http://tnris.org">http://tnris.org</a>.
+        <div class="alert-holder">
         </div>
 
         {% include "./partials/browserwarnings.html" %}


### PR DESCRIPTION
- instead of hiding if it is production, insert warning if it isn't

closes #932 