### PR TITLE
Updating 2020 training reg link

### DIFF
--- a/generate-webpack-config.js
+++ b/generate-webpack-config.js
@@ -151,7 +151,7 @@ function generate(env) {
           "FORUM_YEAR": JSON.stringify("2016"),
           "FORUM_DAY_ONE": JSON.stringify("2016-10-26"),
           "FORUM_DAY_TWO": JSON.stringify("2016-10-27"),
-          "TRAINING_REGISTRATION_LINK": JSON.stringify("https://events.eply.com/TNRISTraining20192740526"),
+          "TRAINING_REGISTRATION_LINK": JSON.stringify("https://events.eply.com/TNRIS2020"),
           "FORUM_REGISTRATION_LINK": JSON.stringify("https://events.eply.com/2019GISForumRegistration")
         }
       }),


### PR DESCRIPTION
Did I do this right? We're getting ready to launch 2020 training and need the new link. Everything seemed to work locally when I tested opening registration for a course on the API (and switched it back to close when i was done.)

If it looks good can we merge so @KCMack can start to open the reg?