### PR TITLE
change datahub icon on front

### DIFF
--- a/templates/partials/quicknav.njk
+++ b/templates/partials/quicknav.njk
@@ -9,7 +9,7 @@
     <a href="https://data.tnris.org" title="Visit the New DataHub!">
       <div class="datahub-quick quick-nav-container center-block">
         <div class="datahub_loader">
-          <img src="https://tnris-org-static.s3.amazonaws.com/images/datahub_loading.gif" alt="DataHub Loading Dots"/>
+          <img src="https://tnris-org-static.s3.amazonaws.com/images/datahub_frontpage_icon.jpg" alt="DataHub Icon Graphic"/>
         </div>
         <div class="datahub-quick-nav-text">
           <em>DataHub</em>


### PR DESCRIPTION
closes #55 

Can we  push this and then I'll provide an image that can go on the datahub itself