### PR TITLE
change format on GIS SG notes list

### DIFF
--- a/templates/gio/gis-solutions-meeting.njk
+++ b/templates/gio/gis-solutions-meeting.njk
@@ -6,37 +6,37 @@
   {# future enhancement needed below to automate the population of sgm meeting notes in a list for the last year (up to 12 documents) #}
   <ul class="list-clean">
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/GIS-SG-Meeting-Notes-2020-01-07_Final.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from January 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/GIS-SG-Meeting-Notes-2020-01-07_Final.pdf"><br><i class="glyphicon glyphicon-file"></i> January 2019: View Notes</a>
     </li>
     <li>
-      <br><i class="glyphicon glyphicon-file"></i> December 2019 - No Meeting Held
+      <br><i class="glyphicon glyphicon-file"></i> December 2019: No Meeting Held
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-11-13-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from November 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-11-13-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> November 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-09-04-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from September 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-09-04-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> September 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-07-16-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from July 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-07-16-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> July 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-06-05-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from June 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-06-05-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> June 2019: View Notes </a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-05-07-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from May 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-05-07-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> May 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-04-02-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from April 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-04-02-GIS-SG-Meeting-Notes.pdf"><br><i class="glyphicon glyphicon-file"></i> April 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-02-26.GIS.SG.Meeting.Notes_0.1.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from February 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-02-26.GIS.SG.Meeting.Notes_0.1.pdf"><br><i class="glyphicon glyphicon-file"></i> February 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-01-29.GIS.SG.Meeting.Notes_0.1.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from January 2019</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/2019-01-29.GIS.SG.Meeting.Notes_0.1.pdf"><br><i class="glyphicon glyphicon-file"></i> January 2019: View Notes</a>
     </li>
     <li>
-      <a href="https://tnris-org-static.s3.amazonaws.com/documents/11-13-2018.GIS.SG.Meeting.Notes_0.2.pdf"><br><i class="glyphicon glyphicon-file"></i> View Notes from November 2018</a>
+      <a href="https://tnris-org-static.s3.amazonaws.com/documents/11-13-2018.GIS.SG.Meeting.Notes_0.2.pdf"><br><i class="glyphicon glyphicon-file"></i> November 2018: View Notes</a>
     </li>
 <!--
     <li>


### PR DESCRIPTION
Made it more consistent, put date first on GIS SG notes list, also in prep for switch to automated list as described in #150