### PR TITLE
StratMap Contract Page Updates/Enhancements

### DIFF
--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -30,11 +30,7 @@ mainimage: https://cdn.tnris.org/images/Vendorbanner.png
 <div class="col-lg-12">
 <h2 class="text-center">Pre-Qualified Geospatial Providers</h2>
 <hr class="clearfix">
-<div class="row">
-	{% include "stratmap/contract-vendors.njk" %}
-</div>
-
-<b>Legend:</b>
+Legend:
 <div class="legend">
    <span class="icon">
 <i class="fa fa-box-open"></i>
@@ -49,6 +45,9 @@ mainimage: https://cdn.tnris.org/images/Vendorbanner.png
         </span>
   <span class="role">Software</span> 
   </div>
+<div class="row">
+	{% include "stratmap/contract-vendors.njk" %}
+</div>
 
 <hr class="clearfix">
 <p>

--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -30,7 +30,7 @@ mainimage: https://cdn.tnris.org/images/Vendorbanner.png
 <div class="col-lg-12">
 <h2 class="text-center">Pre-Qualified Geospatial Providers</h2>
 <hr class="clearfix">
-Legend:
+
 <div class="legend">
    <span class="icon">
 <i class="fa fa-box-open"></i>
@@ -43,7 +43,7 @@ Legend:
     <span class="icon">
   <i class="fa fa-laptop"></i>
         </span>
-  <span class="role">Software</span> 
+  <span class="role">Software</span>
   </div>
 <div class="row">
 	{% include "stratmap/contract-vendors.njk" %}
@@ -131,7 +131,7 @@ Legend:
 							</div>
 						</div>
 					</div>
-				</div>	
+				</div>
 			</div>
 		</section>
 	</div>

--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -34,9 +34,25 @@ mainimage: https://cdn.tnris.org/images/Vendorbanner.png
 	{% include "stratmap/contract-vendors.njk" %}
 </div>
 
+<b>Legend:</b>
+<div class="legend">
+   <span class="icon">
+<i class="fa fa-box-open"></i>
+  </span>
+<span class="role">Products</span>
+  <span class="icon">
+<i class="fa fa-wrench"></i>
+  </span>
+<span class="role"> Services
+    <span class="icon">
+  <i class="fa fa-laptop"></i>
+        </span>
+  <span class="role">Software</span> 
+  </div>
+
 <hr class="clearfix">
 <p>
-<b>Note:</b> On the DIR pages, the original RFO is labeled as "Geographic Information Systems (GIS) Hardware, Software, and Services and Information Technology (IT) Based Surveying Hardware, Software, and Related Services."</b>"</p>
+<b>Note:</b> On the DIR pages, the original RFO is labeled as "Geographic Information Systems (GIS) Hardware, Software, and Services and Information Technology (IT) Based Surveying Hardware, Software, and Related Services."</p>
 
 <div class="container-fluid bg-gray" id="accordion-style-1">
 	<div class="container">

--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -1,81 +1,126 @@
 ---
 title: StratMap Contracts
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/stratmap_website_banner_notext.jpg
+mainimage: https://cdn.tnris.org/images/Vendorbanner.png
 ---
 
 <section class="container-md">
 <div class="row">
 
-<div class="col-lg-8 mx-auto d-block">
-<p class="lead"><strong>After four years of success, the re-bid of StratMap Contracts is happening now!</strong> The solicitation response deadline has passed. We anticipate the new pool of vendors to be available with active DIR master contracts by Summer 2020.
-</p>
-<p>The <a href="https://dir.texas.gov/">Department of Information Resources (DIR)</a> maintains multiple Cooperative Contracts which are designed to strengthen Texas’ capabilities to procure quality digital map data, services and software. The contracts are for use by customers that include Texas state, regional and local government offices, including river and water authorities, and public education entities. The process for procuring GIS products, custom geospatial data and services and software is administered by TNRIS and known as the Texas Strategic Mapping (StratMap) Contracts.</p>
+<div class="col-lg-10 mx-auto d-block">
+<p>The <a href="https://dir.texas.gov/">Department of Information Resources (DIR)</a> maintains multiple Cooperative Contracts which are designed to strengthen Texas’ capabilities to procure quality digital map data, services, and software. The contracts are for use by customers that include Texas state, regional, and local government offices, including river and water authorities, and public education entities. The process for procuring GIS products, services, and software is administered by TNRIS and known as the Texas Strategic Mapping (StratMap) Contracts.</p>
 
-<p>The StratMap/DIR Contracts are awarded to companies which are technically evaluated by a team of GIS professionals and determined to provide quality geographic data products, services, and GIS software. The availability of these contracts streamlines the procurement process for any acquisition of geographic data, services, and software and provides beneficial competition among some of the best companies in the industry.
+<p>The StratMap/DIR Contracts are awarded to companies that are technically evaluated by a team of GIS professionals and determined to provide quality geographic data products, services, and GIS software. The availability of these contracts streamlines the procurement process and provides beneficial competition among some of the best companies in the industry.
 </p>
 
+<p>The StratMap/DIR Contracts are truly a representation of successful public and private partnerships across Texas!
+</p>
+
+<p>To review a list of products, services, or software and associated % discounts, see the Pricing Index for each vendor on their DIR Vendor Contract page.</p>
 </div>
 
-<div class="col-lg-4">
-  <div class="card card-body well-md">
-    <div class="row">
-      <div class="col-lg-12">
-        <img style="max-width: 150px;" src="https://cdn.tnris.org/images/dir_logo_md.png" alt="Texas Department of Information Resources">
-        <h3>DIR-CPO-TMP-444</h3>
-        <p>DIR's 2020 GIS contract initiative is listed as:</p>
-            <h3>Type of Service/Products</h3>
-            <p>Geographic Information Systems (GIS) Hardware, Software, and Services and Information Technology (IT) Based Land Surveying Hardware, Software and Related Services.</p>
-      </div>
+<div class="col-md-2">
+  <div class="row">
+    <div class="col-lg-12">
+      <img style="max-width: 150px;" src="https://cdn.tnris.org/images/dir_logo_md.png" alt="Texas Department of Information Resources">
     </div>
   </div>
 </div>
-<hr>
-<div class="row">
-<div class="col-lg-5">
-<h2>How does this work?</h2>
 
-<p><ul class="stratmap-work">
-<li><strong>New data acquisition projects</strong> are determined by identifying type of data required, location, specification, budget and timeline for delivery.</li>
-<li><strong>Data acquisition, production and independent quality assurance and quality control (QA/QC)</strong> responsibilities are awarded to Vendors who have been awarded geospatial contracts through the Department of Information Resources (DIR).</li>
-<li><strong>After the final data deliverables are accepted</strong>, they are placed in the public domain for use by local, regional and federal government, academia, private industry and the public and maintained by TNRIS.</li>
-</ul></p>
-
-<h2>What are the Benefits?</h2>
-
-<h3>Strategic Collaboration and Integration</h3>
-<p>Bringing together professional expertise across the geospatial community enhances the cohesion of project specifications, provides volume pricing opportunities, ensures the capture of regulatory and industry requirements and results in better quality of data products.</p>
-
-<h3>Taxpayer Value</h3>
-<p>By combining our geospatial projects, we can acquire a larger area at a pre-negotiated discounted unit price and reduce duplication.</p>
-
-<h3>Efficient Purchasing Process</h3>
-<p>Because competitively bid contracts are already in place, the solicitation process has been eliminated for you. A statement of work and a purchase order referencing the Vendor's DIR (StratMap) Contract meets ordering requirements.</p>
-
-<h3>Project Assistance and Coordination</h3>
-<p>There are several product offerings options ranging from self-service to full service. Part of the value that TNRIS brings to the administration of <strong>Texas Strategic Mapping (StratMap) Services</strong> is the expertise that we offer by introducing you to potential project partners to expand the areas of interest or to share the project cost.</p>
-
-<h3>Continuous Improvement</h3>
-<p>Each project performed under the StratMap Services contracts adds to the base of existing valuable historical data and experience and helps to improve data standards and overall project management.</p>
-
-<h3>Increased Opportunity for Cost Sharing</h3>
-
-<p>By taking the first step to notify us about your potential project at: <a href="mailto:StratMap@twdb.texas.gov">StratMap@twdb.texas.gov</a>, you may be alerted to another entity interested in purchasing a similar product or area of interest.</p>
-
-<h3>Pre-screened Companies with Geospatial experience</h3>
-<p>Each of the selected companies were carefully evaluated for project experience and success. Qualifications include project experience, technology innovation, professional staff, and available resources.</p>
-</div>
-
-<div class="col-lg-7">
-<h2 class="text-center">Vendors 2016 - 2020</h2>
-<div class="alert alert-warning text-center"><p class="lead">Note: New vendor pool coming soon.</p></div>
+<div class="col-lg-12">
+<h2 class="text-center">Pre-Qualified Geospatial Providers</h2>
+<hr class="clearfix">
 <div class="row">
 {% include "stratmap/contract-vendors.njk" %}
 </div>
 
 <hr class="clearfix">
 <p>
-<strong>Note:</strong> On the DIR pages, the original RFO is labeled as "​<strong>Geographic Information Systems (GIS) Hardware, Software, and Services.</strong>"</p>
+<b>Note:</b> On the DIR pages, the original RFO is labeled as "Geographic Information Systems (GIS) Hardware, Software, and Services and Information Technology (IT) Based Surveying Hardware, Software, and Related Services."</b>"</p>
+
+<div class="container-fluid bg-gray" id="accordion-style-1">
+	<div class="container">
+		<section>
+			<div class="row">
+				<div class="col-12">
+					<h1 class="text-green mb-4 text-center">Frequently Asked Questions</h1>
+				</div>
+				<div class="col-12 mx-auto">
+					<div class="accordion" id="accordionExample1">
+						<div class="card">
+							<div class="card-header" id="headingA">
+								<h5 class="mb-0">
+							<button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseA" aria-expanded="false" aria-controls="collapseA">
+							  <i class="main"></i><i class="fa fa-angle-double-right mr-3"></i>How does this work for new data acquisition projects?
+							</button>
+						  </h5>
+							</div>
+              	<div id="collapseA" class="collapse fade" aria-labelledby="headingA" data-parent="#accordionExample1">
+								<div class="card-body">
+									<ul><li><b>New data acquisition projects</b> are determined by identifying type of data required, location, specification, budget, and timeline for delivery.</li>
+                  <li><b>Data acquisition, production, and independent quality assurance/quality control (QA/QC)</b> responsibilities are awarded to StratMap/DIR Contract vendors.</li>
+                  <li><b>After the final data deliverables are accepted</b>, they are placed in the public domain for use by local, regional, and federal government, academia, private industry and the public and maintained by TNRIS.</li></ul>
+								</div>
+							</div>
+						</div>
+						<div class="card">
+							<div class="card-header" id="headingB">
+								<h5 class="mb-0">
+							<button class="btn btn-link collapsed btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseB" aria-expanded="false" aria-controls="collapseB">
+							 <i class="main"></i><i class="fa fa-angle-double-right mr-3"></i>What are the benefits for my agency to acquire geospatial data products from the StratMap/DIR Contracts?
+							</button>
+						  </h5>
+							</div>
+							<div id="collapseB" class="collapse fade" aria-labelledby="headingB" data-parent="#accordionExample1">
+								<div class="card-body">
+									<h3>Strategic Collaboration</h3>
+                  Bringing together professional expertise across the geospatial community enhances project specifications, provides volume pricing opportunities, and results in better quality of data products.
+                  <h3>Taxpayer Value</h3>
+                  By combining our geospatial projects, we can acquire a larger area at a pre-negotiated discounted unit price and reduce duplication. Each product, service, and software available from the DIR/StratMap Contracts has an associated % discount.
+                  <h3>Efficient Purchasing Process</h3>
+                  Because competitively bid master contracts are already in place, the contracting process has been eliminated for you. A statement of work and a purchase order referencing the vendor's StratMap/DIR Contract are all that are needed in most cases. State agencies must follow these <a href="https://pubext.dir.texas.gov/portal/internal/resources/DocumentLibrary/Threshold%20and%20SOW%20Quick%20Reference%20Guide.pdf">DIR SOW and Procurement Thresholds</a>.
+                  <h3>Project Assistance and Coordination</h3>
+                  Part of the value that TNRIS brings to the administration of the StratMap/DIR Contracts is the expertise we offer by introducing you to potential project partners to expand the area of interest or to share the project cost. TNRIS StratMap staff provide guidance through the StratMap/DIR Contracts procurement process and in some cases can provide full project management from project initiation to data deliverables review to project close.
+                  <h3>Increased Opportunity for Cost Sharing</h3>
+                  By taking the first step to <b><a href="mailto:StratMap@twdb.texas.gov">notify us</a></b> about your potential project, you may be alerted to another entity interested in purchasing a similar product or area of interest.
+                  <h3>Pre-screened Companies with Geospatial experience</h3>
+                  Each of the selected companies were carefully evaluated for project experience and success. Qualifications include project experience, technology innovation, professional staff, and available resources.
+								</div>
+							</div>
+						</div>
+            <div class="card">
+							<div class="card-header" id="headingC">
+								<h5 class="mb-0">
+							<button class="btn btn-link collapsed btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseC" aria-expanded="false" aria-controls="collapseC">
+							 <i class="main"></i><i class="fa fa-angle-double-right mr-3"></i>How do public and private partnerships further benefit the state of Texas?
+							</button>
+						  </h5>
+							</div>
+							<div id="collapseC" class="collapse fade" aria-labelledby="headingC" data-parent="#accordionExample1">
+								<div class="card-body">
+									<h3>Continuous Improvement</h3>
+                  Each project performed under the DIR/StratMap Contracts adds to the rich base of existing geographic data at TNRIS and through experience gained, helps to improve data standards and overall project management.
+                  <h3>Pre-screened Companies with Geospatial experience</h3>
+                  Each of the selected companies were carefully evaluated for project experience and success. Qualifications include project experience, technology innovation, professional staff, and available resources.<br><br>
+                  <b><a href="mailto:StratMap@twdb.texas.gov">Notify us</a></b> for your geospatial company to be added to the announcement list for future openings to the StratMap/DIR Contract pool.<br><br>
+                  <h3>How does this work for hiring geospatial services?</h3>
+                  To purchase geospatial services from the StratMap/DIR Contracts, follow these simple steps:<br><br>
+                  <ol><li>Review the services available and published % discount on a company’s <b>Pricing Index</b> found on their DIR Vendor Contract page.</li>
+                  <li>Obtain a quote (and if needed, a statement of work) directly from the company contact listed on their DIR Vendor Contract page. The quote should reflect the % discount.</li>
+                  <li>List the company’s DIR Contract Number on your purchase order.</li></ol>
+                  <h3>How does this work for purchasing geospatial software?</h3>
+                  <ol><li>Review the software offerings and published % discount on a company’s <b>Pricing Index</b> found on their DIR Vendor Contract page.</li>
+                  <li>Obtain a quote directly from the company contact listed on their DIR Vendor Contract page. The quote should reflect the % discount.</li>
+                  <li>List the company’s DIR Contract Number on your purchase order.</li></ol>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>	
+			</div>
+		</section>
+	</div>
+</div>
 
 </div>
 

--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -31,7 +31,7 @@ mainimage: https://cdn.tnris.org/images/Vendorbanner.png
 <h2 class="text-center">Pre-Qualified Geospatial Providers</h2>
 <hr class="clearfix">
 <div class="row">
-{% include "stratmap/contract-vendors.njk" %}
+	{% include "stratmap/contract-vendors.njk" %}
 </div>
 
 <hr class="clearfix">

--- a/scss/partials/_stratmap.scss
+++ b/scss/partials/_stratmap.scss
@@ -521,3 +521,17 @@ ul.stratmap-work {
     margin-top: 0;
   }
 }
+
+.legend {
+  font-size: 12px;
+  min-width: 300px;
+  max-width: 300px;
+  padding: 10px;
+  border: 1px solid #e5e5e5;
+  background: #e5e5e5;
+}
+
+.icon {
+  margin-right : 4px;
+  margin-left : 16px;
+}

--- a/scss/partials/_stratmap.scss
+++ b/scss/partials/_stratmap.scss
@@ -526,9 +526,9 @@ ul.stratmap-work {
   font-size: 12px;
   min-width: 300px;
   max-width: 300px;
+  margin-bottom: 20px;
   padding: 10px;
   border: 1px solid #e5e5e5;
-  background: #e5e5e5;
 }
 
 .icon {
@@ -553,6 +553,7 @@ ul.stratmap-work {
 }
 
 .myDiv2 {
+  margin-top: 20px;
   margin-bottom: 10px;
 }
 

--- a/scss/partials/_stratmap.scss
+++ b/scss/partials/_stratmap.scss
@@ -88,24 +88,16 @@
 
 .card.card-body.vendor-box {
   @media (min-width: $screen-sm) {
-    min-height: 275px;
+    min-height: 185px;
     margin-bottom: 1rem;
-  }
-
-  @media (min-width: $screen-md) {
-    min-height: 250px;
-    margin-bottom: 1rem;
+    font-size: 14px;
   }
 
   li {
     margin-bottom: 10px;
 
     a {
-      color: $darkgrey;
-    }
-
-    &:first-child a {
-      color: $tnrisblue;
+      color: #3366BB;
     }
 
 

--- a/scss/partials/_stratmap.scss
+++ b/scss/partials/_stratmap.scss
@@ -535,3 +535,29 @@ ul.stratmap-work {
   margin-right : 4px;
   margin-left : 16px;
 }
+
+.fa.fa-box-open {
+  padding: 0 3px 0 3px
+}
+
+.fa.fa-wrench {
+  padding: 0 3px 0 3px
+}
+
+.fa.fa-laptop {
+  padding: 0 3px 0 3px
+}
+
+.myDiv {
+  height: 25%;
+}
+
+.myDiv2 {
+  margin-bottom: 10px;
+}
+
+.myDiv3 {
+  position: absolute;
+  bottom: 0px;
+  margin: 10px 0 10px 0;
+}

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -91,12 +91,12 @@
     {% else %}
       <div class="card card-body vendor-box">
     {% endif %}
-          <div style="height:25%;">
+          <div class="myDiv">
             <a href="{{item.vendor_home_url}}">
               <img class="img-fluid" src="{{item.logo_url}}" alt="Logo and home page for {{item.name}}">
             </a>
           </div>
-          <div style="margin-bottom:10px;" class="caption">
+          <div class="myDiv2 caption">
               <h3 class="sr-only">{{item.name|safe}}</h3>
               <ul class="list-clean">
               <br>
@@ -117,15 +117,15 @@
                 </li>
               </ul>
           </div>
-          <div style="position:absolute; bottom:0px; margin:10px 0 10px 0;">
+          <div class="myDiv3">
             {% if 'products' in item.tags %}
-              <i style="padding:0 3px 0 3px" class="fa fa-box-open" alt="Products"></i>
+              <i class="fa fa-box-open" alt="Products"></i>
             {% endif %}
             {% if 'services' in item.tags %}
-              <i style="padding:0 3px 0 3px" class="fa fa-wrench" alt="Services"></i>
+              <i class="fa fa-wrench" alt="Services"></i>
             {% endif %}
             {% if 'software' in item.tags %}
-              <i style="padding:0 3px 0 3px" class="fa fa-laptop" alt="Software"></i>
+              <i class="fa fa-laptop" alt="Software"></i>
             {% endif %}
           </div>
       </div>

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -1,79 +1,102 @@
-{% set contract_vendors = [
-  {
-    name: 'AECOM',
-    logo_url: 'https://cdn.tnris.org/images/aecom_logo.png',
-    vendor_home_url: 'https://aecom.com/services/planning-consulting/geospatial-services/',
-    vendor_page_url: 'https://solutions.aecomonline.net/stratmap/',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4495&keyword=aecom'
-  }, 
-  {
-    name: 'Esri',
-    logo_url: 'https://cdn.tnris.org/images/esri_web_md.png',
-    vendor_home_url: 'https://www.esri.com/en-us/home',
-    vendor_page_url: 'http://www.esri.com/landing-pages/texas-dir',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3446&keyword=3446'
-  },
-  {
-    name: 'GeoComm',
-    logo_url: 'https://cdn.tnris.org/images/Geocommlogo.png',
-    vendor_home_url: 'http://www.geo-comm.com/',
-    vendor_page_url: '',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4499&keyword=Geo-Comm'
-  },
-  {
-    name: 'GISinc',
-    logo_url: 'https://cdn.tnris.org/images/GISinclogo.png',
-    vendor_home_url: 'https://www.gisinc.com',
-    vendor_page_url: '',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4503&keyword=GIS%20Inc.'
-  },
-  {
-    name: 'Merrick',
-    logo_url: 'https://cdn.tnris.org/images/Merricklogo.png',
-    vendor_home_url: 'https://www.merrick.com/',
-    vendor_page_url: 'https://www.merrick.com/services/geospatial-services/',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4502&keyword=Merrick'
-  },
-  {
-    name: 'Quantum Spatial',
-    logo_url: 'https://cdn.tnris.org/images/Quantumlogo.png',
-    vendor_home_url: 'http://quantumspatial.com',
-    vendor_page_url: '',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4507&keyword=Quantum%20Spatial'
-  },
-  {
-    name: 'Sanborn',
-    logo_url: 'https://cdn.tnris.org/images/sanborn_logo_sm.jpg',
-    vendor_home_url: 'http://www.sanborn.com/',
-    vendor_page_url: 'https://www.sanborn.com/texasdir/',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4498&keyword=Sanborn'
-  },
-  {
-    name: 'Surdex',
-    logo_url: 'https://cdn.tnris.org/images/surdex_logo_sm.jpg',
-    vendor_home_url: 'https://www.surdex.net/',
-    vendor_page_url: 'https://www.sanborn.com/texasdir/',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4496&keyword=Surdex'
-  },
-  {
-    name: 'Woolpert',
-    logo_url: 'https://cdn.tnris.org/images/Woolpertlogo.png',
-    vendor_home_url: 'https://woolpert.com/',
-    vendor_page_url: '',
-    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4508&keyword=Woolpert'
-  }
+{% set contract_vendors = 
+  [
+    {
+      name: 'AECOM',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/aecom_logo.png',
+      vendor_home_url: 'https://aecom.com/services/planning-consulting/geospatial-services/',
+      vendor_page_url: 'https://solutions.aecomonline.net/stratmap/',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4495&keyword=aecom',
+      tags: ['products','services']
+    }, 
+    {
+      name: 'Esri',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/esri_web_md.png',
+      vendor_home_url: 'https://www.esri.com/en-us/home',
+      vendor_page_url: 'http://www.esri.com/landing-pages/texas-dir',
+      dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3446&keyword=3446',
+      tags: ['software']
+    },
+    {
+      name: 'GeoComm',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/Geocommlogo.png',
+      vendor_home_url: 'http://www.geo-comm.com/',
+      vendor_page_url: '',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4499&keyword=Geo-Comm',
+      tags: ['services','software']
+    },
+    {
+      name: 'GISinc',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/GISinclogo.png',
+      vendor_home_url: 'https://www.gisinc.com',
+      vendor_page_url: '',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4503&keyword=GIS%20Inc.',
+      tags: ['services']
+    },
+    {
+      name: 'Merrick',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/Merricklogo.png',
+      vendor_home_url: 'https://www.merrick.com/',
+      vendor_page_url: 'https://www.merrick.com/services/geospatial-services/',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4502&keyword=Merrick',
+      tags: ['products','services']
+    },
+    {
+      name: 'Quantum Spatial',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/Quantumlogo.png',
+      vendor_home_url: 'http://quantumspatial.com',
+      vendor_page_url: '',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4507&keyword=Quantum%20Spatial',
+      tags: ['products','services']
+    },
+    {
+      name: 'Sanborn',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/sanborn_logo_sm.jpg',
+      vendor_home_url: 'http://www.sanborn.com/',
+      vendor_page_url: 'https://www.sanborn.com/texasdir/',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4498&keyword=Sanborn',
+      tags: ['products','services']
+    },
+    {
+      name: 'Surdex',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/surdex_logo_sm.jpg',
+      vendor_home_url: 'https://www.surdex.net/',
+      vendor_page_url: 'https://www.sanborn.com/texasdir/',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4496&keyword=Surdex',
+      tags: ['products','services']
+    },
+    {
+      name: 'Woolpert',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/Woolpertlogo.png',
+      vendor_home_url: 'https://woolpert.com/',
+      vendor_page_url: '',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4508&keyword=Woolpert',
+      tags: ['products','services']
+    }
   ]
-  %}
+%}
 
 {% for item in contract_vendors %}
-  <div class="col-lg-2">
+  <div class="col-lg-2 d-flex align-items-stretch">
     {% if item.status == 'unavailable' %}
     <div class="card card-body vendor-box unavailable">
     {% else %}
       <div class="card card-body vendor-box">
     {% endif %}
-          <a href="{{item.vendor_home_url}}"><img class="img-fluid" src="{{item.logo_url}}" alt="Logo and home page for {{item.name}}"></a>
-          <div class="caption">
+          <div style="height:25%;">
+            <a href="{{item.vendor_home_url}}">
+              <img class="img-fluid" src="{{item.logo_url}}" alt="Logo and home page for {{item.name}}">
+            </a>
+          </div>
+          <div style="margin-bottom:10px;" class="caption">
               <h3 class="sr-only">{{item.name|safe}}</h3>
               <ul class="list-clean">
               <br>
@@ -93,6 +116,17 @@
                  {% endif %}
                 </li>
               </ul>
+          </div>
+          <div style="position:absolute; bottom:0px; margin:10px 0 10px 0;">
+            {% if 'products' in item.tags %}
+              <i style="padding:0 3px 0 3px" class="fa fa-box-open" alt="Products"></i>
+            {% endif %}
+            {% if 'services' in item.tags %}
+              <i style="padding:0 3px 0 3px" class="fa fa-server" alt="Services"></i>
+            {% endif %}
+            {% if 'software' in item.tags %}
+              <i style="padding:0 3px 0 3px" class="fa fa-laptop" alt="Software"></i>
+            {% endif %}
           </div>
       </div>
   </div>

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -122,7 +122,7 @@
               <i style="padding:0 3px 0 3px" class="fa fa-box-open" alt="Products"></i>
             {% endif %}
             {% if 'services' in item.tags %}
-              <i style="padding:0 3px 0 3px" class="fa fa-server" alt="Services"></i>
+              <i style="padding:0 3px 0 3px" class="fa fa-wrench" alt="Services"></i>
             {% endif %}
             {% if 'software' in item.tags %}
               <i style="padding:0 3px 0 3px" class="fa fa-laptop" alt="Software"></i>

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -104,7 +104,7 @@
                 {% if item.vendor_page_url %}
                 <a href="{{item.vendor_page_url}}"><i class="fa fa-new-window"></i>Contract Page</a>
                 {% else %}
-                <em>Vendor Contract Page in progress</em>
+                <em>Contract Page in progress</em>
                 {% endif %}
                 </li>
 

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -2,112 +2,71 @@
   {
     name: 'AECOM',
     logo_url: 'https://cdn.tnris.org/images/aecom_logo.png',
-    vendor_home_url: 'https://www.aecom.com',
-    vendor_page_url: 'http://www.aecomconnect.com/arcgisportal/apps/MapJournal/index.html?appid=f8ec753f87964dd980bee9f79b16ead7',
-    status: 'unavailable'
-  }, {
-    name: 'AppGeo',
-    logo_url: 'https://cdn.tnris.org/images/appgeo_logo_sm.png',
-    vendor_home_url: 'http://www.appgeo.com/',
-    vendor_page_url: 'http://www.appgeo.com/about/contracting-with-appgeo-is-easy/texas-dir-tso-3417/#more-4656',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3417&keyword=applied%20geographics'
-  },
-  {
-    name: 'Dewberry',
-    logo_url: 'https://cdn.tnris.org/images/dewberry_logo.png',
-    vendor_home_url: 'http://www.dewberry.com/  ',
-    vendor_page_url: 'http://www.dewberry.com/services/geospatial/texas-dir',
-    status: 'unavailable'
-  },
+    vendor_home_url: 'https://aecom.com/services/planning-consulting/geospatial-services/',
+    vendor_page_url: 'https://solutions.aecomonline.net/stratmap/',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4495&keyword=aecom'
+  }, 
   {
     name: 'Esri',
     logo_url: 'https://cdn.tnris.org/images/esri_web_md.png',
-    vendor_home_url: 'http://www.esri.com/',
+    vendor_home_url: 'https://www.esri.com/en-us/home',
     vendor_page_url: 'http://www.esri.com/landing-pages/texas-dir',
     dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3446&keyword=3446'
   },
   {
-    name: 'Fugro Geospatial',
-    logo_url: 'https://cdn.tnris.org/images/fugro_logo.jpg',
-    vendor_home_url: 'http://www.fugrogeospatial.com/',
-    vendor_page_url: ' http://www.fugrogeospatial.com/txdir',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3391&keyword=fugro%20geospatial'
-  },
-  {
     name: 'GeoComm',
-    logo_url: 'https://cdn.tnris.org/images/geocomm_logo.png',
+    logo_url: 'https://cdn.tnris.org/images/Geocommlogo.png',
     vendor_home_url: 'http://www.geo-comm.com/',
-    vendor_page_url: 'http://www.geo-comm.com/2016texas-dircontract/',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3441&keyword=geo-comm'
+    vendor_page_url: '',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4499&keyword=Geo-Comm'
   },
   {
-    name: 'Geophex',
-    logo_url: 'https://cdn.tnris.org/images/geophex_logo.png',
-    vendor_home_url: 'http://www.geophex.com/',
-    vendor_page_url: 'http://geophexsurveys.com/dir-contractor-geographic-data-provider/',
-    status: 'unavailable'
+    name: 'GISinc',
+    logo_url: 'https://cdn.tnris.org/images/GISinclogo.png',
+    vendor_home_url: 'https://www.gisinc.com',
+    vendor_page_url: '',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4503&keyword=GIS%20Inc.'
   },
   {
     name: 'Merrick',
-    logo_url: 'https://cdn.tnris.org/images/merrick_logo.png',
+    logo_url: 'https://cdn.tnris.org/images/Merricklogo.png',
     vendor_home_url: 'https://www.merrick.com/',
     vendor_page_url: 'https://www.merrick.com/services/geospatial-services/',
-    status: 'unavailable'
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4502&keyword=Merrick'
   },
   {
-    name: 'PenBay',
-    logo_url: 'https://cdn.tnris.org/images/penbay_logo.png',
-    vendor_home_url: 'http://penbaysolutions.com/',
-    vendor_page_url: 'http://penbaysolutions.com/texas-dir/',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3397&keyword=penbay'
-  },
-  {
-    name: 'RazorTek',
-    logo_url: 'https://cdn.tnris.org/images/razorlizard_web.png',
-    vendor_home_url: 'http://www.razor-tek.com/',
-    vendor_page_url: 'https://www.razor-tek.com/tx-dir-info',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3471&keyword=razortek'
-  },
-  {
-    name: 'SADA Systems',
-    logo_url: 'https://cdn.tnris.org/images/sada_logo.jpg',
-    vendor_home_url: 'https://sadasystems.com/',
-    vendor_page_url: 'https://sadasystems.com/cloud-solutions/google-for-work/apps/government/certifications/contracts/DIR-TSO-3413',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3413&keyword=Sada'
+    name: 'Quantum Spatial',
+    logo_url: 'https://cdn.tnris.org/images/Quantumlogo.png',
+    vendor_home_url: 'http://quantumspatial.com',
+    vendor_page_url: '',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4507&keyword=Quantum%20Spatial'
   },
   {
     name: 'Sanborn',
     logo_url: 'https://cdn.tnris.org/images/sanborn_logo_sm.jpg',
     vendor_home_url: 'http://www.sanborn.com/',
-    vendor_page_url: 'http://www.sanborn.com/texasdir-dir-tso-3395/',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3395&keyword=Sanborn'
+    vendor_page_url: 'https://www.sanborn.com/texasdir/',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4498&keyword=Sanborn'
   },
   {
     name: 'Surdex',
     logo_url: 'https://cdn.tnris.org/images/surdex_logo_sm.jpg',
     vendor_home_url: 'https://www.surdex.net/',
-    vendor_page_url: 'https://www.texas-geospatial.com/',
-    status: 'unavailable'
+    vendor_page_url: 'https://www.sanborn.com/texasdir/',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4496&keyword=Surdex'
   },
   {
-    name: 'Tessellations',
-    logo_url: 'https://cdn.tnris.org/images/tesselations_logo.jpg',
-    vendor_home_url: 'http://tessellations.us/',
-    vendor_page_url: 'http://tessellations.us/?page_id=675',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3443&keyword=tessellations'
-  },
-  {
-    name: 'West Corporation',
-    logo_url: 'https://cdn.tnris.org/images/west_logo.png',
-    vendor_home_url: 'https://www.west.com/',
-    vendor_page_url: ' https://www.west.com/safety-services/partners/texas-department-of-information-resources/',
-    dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3468&keyword=West'
+    name: 'Woolpert',
+    logo_url: 'https://cdn.tnris.org/images/Woolpertlogo.png',
+    vendor_home_url: 'https://woolpert.com/',
+    vendor_page_url: '',
+    dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4508&keyword=Woolpert'
   }
   ]
   %}
 
 {% for item in contract_vendors %}
-  <div class="col-sm-6">
+  <div class="col-lg-2">
     {% if item.status == 'unavailable' %}
     <div class="card card-body vendor-box unavailable">
     {% else %}
@@ -117,13 +76,10 @@
           <div class="caption">
               <h3 class="sr-only">{{item.name|safe}}</h3>
               <ul class="list-clean">
-                <li><a href="{{item.vendor_home_url}}">
-                  <i class="fa fa-home"></i> Vendor Home</a>
-                </li>
-
+              <br>
                 <li>
                 {% if item.vendor_page_url %}
-                <a href="{{item.vendor_page_url}}"><i class="fa fa-new-window"></i> Vendor Contract Page</a>
+                <a href="{{item.vendor_page_url}}"><i class="fa fa-new-window"></i>Contract Page</a>
                 {% else %}
                 <em>Vendor Contract Page in progress</em>
                 {% endif %}
@@ -131,7 +87,7 @@
 
                 <li>
                 {% if item.dir_page_url %}
-                <a href="{{item.dir_page_url}}"><i class="fa fa-new-window"></i> DIR Vendor Contract Page</a>
+                <a href="{{item.dir_page_url}}"><i class="fa fa-new-window"></i>DIR Contract Page</a>
                 {% else %}
                 <em>DIR Contract Expired</em>
                  {% endif %}


### PR DESCRIPTION
Refer to issue #263 

StratMaps Contract page updates

-updated text content
-made "vendor" cards smaller and fit full page width
-removed "vendor home" URL (now accessible only via logo)
-updated contract/DIR contract URLs based on current active contracts
-moved "FAQs" below "vendors" and made collapsible
-updated banner image to include word cloud