### PR TITLE
Resizing banner images to matching heights

### DIFF
--- a/content/markdown/education/index.md
+++ b/content/markdown/education/index.md
@@ -3,8 +3,8 @@ title: Education and Training
 layout: education/main.njk
 mainimage: https://cdn.tnris.org/images/keep_pace_banner.jpg
 smallimage: https://cdn.tnris.org/images/training_keep_pace_md.jpg
-abstract: Technical training courses bring the latest GIS technologies and skills to a range of professional skill levels in the workplace.
 ---
+Technical training courses bring the latest GIS technologies and skills to a range of professional skill levels in the workplace.
 
 Courses offered range from basic introductions to software use and application, to intermediate skill enhancement and refinement, to more advanced skill development for increased efficiency and effective use of GIS.
 

--- a/content/markdown/stratmap/elevation-lidar.md
+++ b/content/markdown/stratmap/elevation-lidar.md
@@ -1,7 +1,7 @@
 ---
 title: Elevation – Lidar
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/lidar_banner.jpg
+mainimage: https://cdn.tnris.org/images/SB_Lidar.png
 ---
 
 <div class="container-md">

--- a/content/markdown/stratmap/hydrography.md
+++ b/content/markdown/stratmap/hydrography.md
@@ -1,7 +1,7 @@
 ---
 title: Hydrography
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/hydro_banner.jpg
+mainimage: https://cdn.tnris.org/images/SB_Hydrography.png
 ---
 
 <div class="container-md">

--- a/content/markdown/stratmap/index.md
+++ b/content/markdown/stratmap/index.md
@@ -1,7 +1,7 @@
 ---
 title: StratMap - Strategic Mapping Program
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/stratmap_main_banner.png
+mainimage: https://cdn.tnris.org/images/SB_main.png
 ---
 <div>
 {% include "stratmap/main-content.njk" %}

--- a/content/markdown/stratmap/orthoimagery.md
+++ b/content/markdown/stratmap/orthoimagery.md
@@ -1,7 +1,7 @@
 ---
 title: Orthoimagery
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/orthoreview_main.jpg
+mainimage: https://cdn.tnris.org/images/SB_Ortho.png
 ---
 <div class="container-md">
   <div class="row">

--- a/content/markdown/stratmap/stratmap-contracts.md
+++ b/content/markdown/stratmap/stratmap-contracts.md
@@ -1,7 +1,7 @@
 ---
 title: StratMap Contracts
 layout: stratmap/main.njk
-mainimage: https://cdn.tnris.org/images/tx_word_banner.png
+mainimage: https://cdn.tnris.org/images/SB_Contracts.png
 ---
 
 <section class="container-md">

--- a/templates/education/main.njk
+++ b/templates/education/main.njk
@@ -7,20 +7,26 @@
 
 {% block topcontent %}
   <div class="container-fluid full">
-    <div class="top-container">
-      {% if mainimage %}
-        <img class="img-fluid mx-auto d-md-block d-none" src="{{mainimage}}" alt="Masthead for {{title}}">
-      {% endif %}
-      {% if smallimage %}
-        <img class="img-fluid mx-auto d-block d-md-none d-lg-none" src="{{smallimage}}" alt="Masthead for {{title}}">
-      {% endif %}
-    </div>
+
+        <div class="top-container">
+        {% if mainimage %}
+          <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+        {% endif %}
+
+        <div class="top-header mx-auto d-block">
+            <div class="container-md">
+              <h1>{{title}}</h1>
+              {% if abstract %}
+                <div class="lead">{{abstract}}</div>
+              {% endif %}
+            </div>
+        </div>
+        </div>
   </div>
 {% endblock %}
 
 {% block contentsOne %}
   <div class="container-md">
-    <h1 id="title">{{title}}</h1>
     {% if abstract %}
       <div class="lead">{{abstract}}</div>
     {% endif %}

--- a/templates/stratmap/ap-lp-page.njk
+++ b/templates/stratmap/ap-lp-page.njk
@@ -7,12 +7,10 @@
   </div>
 </div>
 <div class="container-fluid full">
-  <div class="top-container">
-      <div class="container-md" class="embed-responsive embed-responsive-16by9">
-        <div class="embed-responsive embed-responsive-16by9">
-          <iframe src="{{youtube_url}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <div class="container-md" class="embed-responsive embed-responsive-21by9">
+        <div class="embed-responsive embed-responsive-21by9">
+          <iframe class="embed-responsive-item youtube"  src="{{youtube_url}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
-      </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
refer issue #273 

-New banner images for all Stratmaps tabs to make same height
-Youtube video aspect ratio changed to more closely match banner height (Stratmap Land Parcels & Address Points tabs)
-Slight modifications to Education & Training layout to match Teacher Resources page