### PR TITLE
Revised training card layout & improved site accessibility

### DIFF
--- a/content/markdown/education/teachers.md
+++ b/content/markdown/education/teachers.md
@@ -6,14 +6,14 @@ mainimage: https://cdn.tnris.org/images/rovers3.jpg
 
 <div class="row">
 <div class="col-lg-8">
-<p class="lead">TNRIS has many maps and data resources available to the public at no charge from our website that can be incorporated into teacher's lesson plans for all levels. In addition to these resources, we are able to give tours on a limited basis to students and their educators.</p>
+<p class="lead"><br>TNRIS has many maps and data resources available to the public at no charge from our website that can be incorporated into teacher's lesson plans for all levels. In addition to these resources, we are able to give tours on a limited basis to students and their educators.</p>
 </div>
 <div class="col-lg-4">
   <div class="card card-body well-bg">
   <p>
     Contact us about our Education &amp; Training Program.
   </p>
-  <a class="btn btn-tnris btn-lg btn-block" href="/education/contact"><i class="fa fa-comment"></i> Contact Us</a>
+  <a id="ContactEducation" class="btn btn-tnris btn-lg btn-block" href="/education/contact" aria-labelledby="ContactEducation"><i class="fa fa-comment"></i> Contact Us</a>
   </div>
 </div>
 </div>
@@ -146,17 +146,17 @@ mainimage: https://cdn.tnris.org/images/rovers3.jpg
 
 <h3>Esri Training Catalog</h3>
 
-<p><a class="btn btn-tnris btn-md float-right" href="https://www.esri.com/training/catalog/search/">Learn more</a> Esri offers online, free courses to help you get started with their software.
+<p><a id="EsriTraining" class="btn btn-tnris btn-md float-right" href="https://www.esri.com/training/catalog/search/" aria-labelledby="EsriTraining">Learn more</a> Esri offers online, free courses to help you get started with their software.
 </p>
 
 <h3>ArcGIS Student License</h3>
 
-<p><a class="btn btn-tnris btn-md float-right" href="https://www.esri.com/en-us/arcgis/products/arcgis-desktop-student-trial">Learn more</a> Esri offers ArcGIS for Student use to learn GIS technical skills.
+<p><a id="ArcGISstudent" class="btn btn-tnris btn-md float-right" href="https://www.esri.com/en-us/arcgis/products/arcgis-desktop-student-trial" aria-labelledby="ArcGISstudent">Learn more</a> Esri offers ArcGIS for Student use to learn GIS technical skills.
 </p>
 
 <h3>Austin Community College</h3>
 
-<p><a class="btn btn-tnris btn-md float-right" href="https://www.austincc.edu/academic-and-career-programs/areas-of-study/design-manufacturing-construction-and-applied-technologies/geographic-information-systems">Learn more</a> ACC's Geographic Information Systems Program starts with basic GIS principles and techniques then progresses through GIS projects and performing sophisticated analysis.
+<p><a id="ACCGIS" class="btn btn-tnris btn-md float-right" href="https://www.austincc.edu/academic-and-career-programs/areas-of-study/design-manufacturing-construction-and-applied-technologies/geographic-information-systems" aria-labelledby="ACCGIS">Learn more</a> ACC's Geographic Information Systems Program starts with basic GIS principles and techniques then progresses through GIS projects and performing sophisticated analysis.
 </p>
 </div>
 </div>

--- a/content/markdown/stratmap/address-points.md
+++ b/content/markdown/stratmap/address-points.md
@@ -170,7 +170,7 @@ youtube_url: https://www.youtube.com/embed/OAs1wSw3xQ0
 
 <h3>What is the purpose of these address points?</h3>
 
-<p>These address points were created for 9-1-1 call routing purposes; however, they are now available for public use.  The <a href="https://www.911.gov/issue_nextgeneration911.html">Next Generation 9-1-1 (NG911)</a> system will rely heavily on the accuracy of geospatial data, including address points.  As a result, these data are continually scrubbed and analyzed for use within the NG911 system by the authoritative data sources and their vendors.  Over time, these data may change based on GIS standards established by the <a href="https://www.nena.org/page/NG911GISDataModel">National Emergency Number Association (NENA)</a> or for other reasons.  TNRIS does not edit these data.</p>
+<p>These address points were created for 9-1-1 call routing purposes; however, they are now available for public use.  The <a href="https://www.911.gov/issue_nextgeneration911.html">Next Generation 9-1-1 (NG911)</a> system will rely heavily on the accuracy of geospatial data, including address points.  As a result, these data are continually scrubbed and analyzed for use within the NG911 system by the authoritative data sources and their vendors.  Over time, these data may change based on GIS standards established by the <a id="NENAdatamodel" href="https://www.nena.org/page/NG911GISDataModel" aria-labelledby="NENAdatamodel">National Emergency Number Association (NENA)</a> or for other reasons.  TNRIS does not edit these data.</p>
 
 * * *
 

--- a/scss/partials/_education.scss
+++ b/scss/partials/_education.scss
@@ -38,7 +38,7 @@ h1 {
     margin-bottom: 10px;
 
     #category-filter-dropdown-btn {
-      width: 240px;
+      width: auto;
       overflow: hidden;
       text-overflow: ellipsis;
       text-align: left;
@@ -119,7 +119,7 @@ h1 {
 
     h3 {
       font-size: 22px;
-      margin-top: 0;
+      margin-top: -20px;
     }
 
     .row {
@@ -481,4 +481,49 @@ h2.teachmegis-header {
   @media (min-width: $screen-sm) {
     border-right: 1px solid $lightgrey;
   }
+}
+
+.classdate {
+  text-align: right;
+}
+
+.btn.btn-danger {
+  width: 100%;
+  min-width: 55px;
+}
+
+.btn.btn-success {
+  width: 100%;
+  min-width: 55px;
+}
+
+.btn.btn-primary {
+  width: 100%;
+  min-width: 55px;
+}
+
+.full-details-btn {
+  width: 100%;
+  min-width: 55px;
+}
+
+.copy-url-btn {
+  width: 100%;
+  min-width: 85px;
+}
+
+.course-info2 {
+  font-size: 16px;
+}
+
+h5 {
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: -5px;
+  margin-bottom: 10px;
+}
+
+hr.new1 { 
+  margin-top: -15px;
+  margin-bottom: 25px;
 }

--- a/static/js/training.js
+++ b/static/js/training.js
@@ -52,7 +52,7 @@ function retrieveTraining(queryField, queryValue) {
         if (today < end) {
           // set to active enabled register button with proper link to external registration page
           status = `<a href="${t.training_link}" class="btn btn-success btn-sm">
-                      <i class="fa fa-new-window"></i> Register
+                      <i class="fa fa-calendar-check-o" aria-hidden="true"></i> Register
                     </a>`;
         }
         else if (today >= end) {
@@ -88,33 +88,42 @@ function retrieveTraining(queryField, queryValue) {
           <div class="col-12 course-info-category">
             ${t.category}
           </div>
-          <div class="col-12 col-sm-3 course-date-time">
-            <strong>
+          <div class="col-12">
+            <div class="row">
+              <div class="col-8"><br>
+                <h3><b>
+                  ${t.title}</b>
+                </h3>
+              </div>
+              <div class="col-4 classdate">
+              <strong>
               <span class="fa fa-calendar"></span>
               ${month} ${day}, ${t.year}
             </strong><br>
             <i class="fa fa-time"></i>
-            ${start_time} - ${end_time} <br>
-            <button class="btn btn-primary btn-sm full-details-btn" type="button" data-toggle="collapse" aria-expanded="false" data-target="#Sheet${t.training_id}">
-              <span class="fa fa-info-sign"></span>
-              Expand Details
+            ${start_time} - ${end_time} 
+              </div>
+              <div class="col-8 course-info2">
+                <strong>Taught by:</strong> ${t.instructor}<br>
+                <strong>Cost:</strong> $${t.cost}
+              </div>
+              <div class="col-2 course-info">
+              <button class="btn btn-primary btn-sm full-details-btn" type="button" data-toggle="collapse" aria-expanded="false" data-target="#Sheet${t.training_id}">
+              <span class="fa fa-caret-down"></span>
+              Details
             </button>
+            </div>
+              <div class="col-2 course-info"> ${status}
+              </div>
+            </div>
           </div>
-          <div class="col-12 col-sm-9">
-            <div class="row">
-              <div class="col-12">
-                <h3>
-                  ${t.title}
-                </h3>
-              </div>
-              <div class="col-3 course-info">
-                <strong>Taught by:</strong>
-                <br> ${t.instructor}
-              </div>
-              <div class="col-3 course-info">
-                <strong>Cost:</strong><br> $${t.cost}
-              </div>
-              <div class="col-3 course-info">
+          <div id="Sheet${t.training_id}" class="course-description col-12 collapse" style="padding:20px;">
+            <hr class="new1">
+            <h5>Description</h5>
+            ${t.description}
+            <!-- if there are public registration_open records, insert discount copy content in each record html -->
+            <!-- <div id="training-discount-copy-record" style="padding:25px 0 0 0;"></div> -->
+            <div class="col-3 course-info">
                 <strong>Share:</strong><br>
                 <span class="input-group-btn">
                   <button class="btn btn-tnris btn-sm copy-url-btn" type="button" style="margin-top:0; width:95%;">
@@ -123,16 +132,6 @@ function retrieveTraining(queryField, queryValue) {
                 </span>
                 <input class="form-control hidden-clipboard-input" type="text" readonly value="${location.origin}/education#${urlTitle}">
               </div>
-              <div class="col-3 course-info">
-                <strong>Status:</strong><br> ${status}
-              </div>
-            </div>
-          </div>
-          <div id="Sheet${t.training_id}" class="course-description col-12 collapse" style="padding:20px;">
-            <h3>Description</h3>
-            ${t.description}
-            <!-- if there are public registration_open records, insert discount copy content in each record html -->
-            <!-- <div id="training-discount-copy-record" style="padding:25px 0 0 0;"></div> -->
           </div>
         </div>`;
 
@@ -156,7 +155,7 @@ function retrieveTraining(queryField, queryValue) {
       });
       button.click();
       button.className = 'btn btn-warning btn-sm full-details-btn';
-      button.innerHTML = "<span class='fa fa-info-sign'></span> Close Details";
+      button.innerHTML = "<span class='fa fa-caret-up'></span> Close";
     }
   })
   .then(function() {
@@ -168,7 +167,7 @@ function retrieveTraining(queryField, queryValue) {
       b.addEventListener("click", function() {
         // if event is fired to expand description, scroll to course great-grandparent ".training-record"
         // if event is fired to collapse, no scrolling
-        if (b.innerHTML.includes('Expand')) {
+        if (b.innerHTML.includes('Details')) {
           b.parentNode.parentNode.parentNode.scrollIntoView({
             behavior: 'smooth'
           });
@@ -177,7 +176,7 @@ function retrieveTraining(queryField, queryValue) {
           window.history.pushState(null, "", window.location.href.replace(location.hash, ""));
         }
         b.classList.contains('btn-primary') ? b.className = 'btn btn-warning btn-sm full-details-btn' : b.className = 'btn btn-primary btn-sm full-details-btn';
-        b.innerHTML.includes('Expand') ? b.innerHTML = "<span class='fa fa-info-sign'></span> Close Details" : b.innerHTML = "<span class='fa fa-info-sign'></span> Expand Details";
+        b.innerHTML.includes('Details') ? b.innerHTML = "<span class='fa fa-caret-up'></span> Close" : b.innerHTML = "<span class='fa fa-caret-down'></span> Details";
       });
     });
   });

--- a/static/js/training.js
+++ b/static/js/training.js
@@ -148,7 +148,7 @@ function retrieveTraining(queryField, queryValue) {
     // this is for sharing urls to training records
     var clickId = location.hash.replace("#", "");
     var element = clickId ? document.getElementById(clickId) : "";
-    var button = element ? element.children[0].children[1].children[4] : '';
+    var button = element ? element.children[0].children[1].children[0].children[3].children[0] : '';
     if (location.hash) {
       element.scrollIntoView({
         behavior: 'smooth'

--- a/templates/education/education-side.njk
+++ b/templates/education/education-side.njk
@@ -30,7 +30,7 @@
   <p>
     Contact us about our Education &amp; Training Program.
   </p>
-  <a class="btn btn-tnris btn-lg btn-block" href="/education/contact"><i class="fa fa-comment"></i> Contact Us</a>
+  <a id="ContactEducation" class="btn btn-tnris btn-lg btn-block" href="/education/contact" aria-labelledby="ContactEducation"><i class="fa fa-comment"></i> Contact Us</a>
 </div>
 <hr class="clearfix">
 <div class="alert alert-info">

--- a/templates/education/main.njk
+++ b/templates/education/main.njk
@@ -47,6 +47,7 @@
           </div>
           <div class="col-lg-6">
             <div id="category-filter-dropdown" class="dropdown float-right">
+            <div style="display: flex; justify-content: flex-end">
               Filter Courses:	&nbsp;
               <button id="category-filter-dropdown-btn" class="btn btn-secondary dropdown-toggle" type="button" id="categoryFilterMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <span class="caret"></span>
@@ -54,8 +55,8 @@
               </button>
               <ul id="category-dropdown-menu" class="dropdown-menu" aria-labelledby="categoryFilterMenu">
                 <li class="category-dropdown-menu-item">All Courses</li>
-                <li role="separator" class="divider"></li>
               </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/templates/education/main.njk
+++ b/templates/education/main.njk
@@ -47,7 +47,7 @@
           </div>
           <div class="col-lg-6">
             <div id="category-filter-dropdown" class="dropdown float-right">
-            <div style="display: flex; justify-content: flex-end">
+            <div style="display: flex; justify-content: flex-end;">
               Filter Courses:	&nbsp;
               <button id="category-filter-dropdown-btn" class="btn btn-secondary dropdown-toggle" type="button" id="categoryFilterMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <span class="caret"></span>


### PR DESCRIPTION
GIS Training Course cards re-designed to align better to grid:
-"copy link" button moved to show when card details expanded
-new FA icons used on buttons
"Expand Details" and "Close Details" changed to "Expand" and "Close"
-"Filter Courses" changed to align to right side of cards and match to width of selected item

**Notes:
-When testing expand/collapse, every once in a while it will break and show the opposite button. This is especially likely if you double-click, though when testing the current version this also seems to be an issue there.
-The buttons (Details & Register) are pretty squished together when viewing on mobile. I don't think it's perfect but was the best I could get to work without compromising something else. Might be better if they stack? 

Aria Labels (issue #260) :
-Pages that have instances where the same text links to different URLs can be difficult to distinguish for people using screen readers. Adding aria labels helps improve accessibility for these users.