### PR TITLE
Update to front page carousel

### DIFF
--- a/scss/partials/_dataspot.scss
+++ b/scss/partials/_dataspot.scss
@@ -25,7 +25,6 @@
   }
   // end Carousel
 
-
   .spotText {
     background: rgba(0,0,0,.75);
     border-radius: 10px;
@@ -239,3 +238,8 @@
     color: white;
     }
 }
+
+.carousel-caption {
+  text-shadow: 3px 3px 8px #000000;
+}
+

--- a/templates/partials/mainfeature.njk
+++ b/templates/partials/mainfeature.njk
@@ -12,27 +12,17 @@
     <li data-target="#tnris-carousel" data-slide-to="1"></li>
     <li data-target="#tnris-carousel" data-slide-to="2"></li>
     <li data-target="#tnris-carousel" data-slide-to="3"></li>
-    <li data-target="#tnris-carousel" data-slide-to="4"></li>
-    <li data-target="#tnris-carousel" data-slide-to="5"></li>
-    {# <li data-target="#tnris-carousel" data-slide-to="6"></li> #}
+    {# <li data-target="#tnris-carousel" data-slide-to="4"></li> #}
   </ol>
 
   <!-- Wrapper for slides -->
   <div id="carousel-wrapper" class="carousel-inner" role="listbox">
     <div class="carousel-item active">
-      <a href="https://cdn.tnris.org/documents/GIS_Agenda_Q4_2020.pdf" target="_blank">
-        <img class="d-block img-fluid" src="https://cdn.tnris.org/images/Q42020Agenda_.png" alt="Q4 2020 Meeting Agenda">
-      </a>
-    </div>
-    <div class="carousel-item">
-      <img class="d-block img-fluid" src="https://cdn.tnris.org/images/covid-19_forum_banner_notice_21:9.jpg" alt="COVID-19 Texas GIS Forum Notice">
-    </div>
-    <div class="carousel-item">
-      <a href="https://data.tnris.org" target="_blank">
-        <img class="d-block img-fluid" src="https://cdn.tnris.org/images/forum_adam_dataHub_banner_21:9_wBubble.png" alt="Forum DataHub Adam">
+      <a href="https://data.tnris.org/collection/f84442b8-ac2a-4708-b5c0-9d15515f4483" target="_blank">
+        <img class="d-block img-fluid" src="https://cdn.tnris.org/images/cap_area_ortho_dam_banner_21:9.jpg" alt="StratMap 2019 CapArea Imagery">
       </a>
       <div class="carousel-caption">
-        <p>2019 Texas GIS Forum - TNRIS DataHub Presentation</p>
+        <p>Imagery Preview - StratMap 2019 CapArea Imagery</p>
       </div>
     </div>
     <div class="carousel-item">
@@ -44,19 +34,19 @@
       </div>
     </div>
     <div class="carousel-item">
-      <a href="https://data.tnris.org/collection/f84442b8-ac2a-4708-b5c0-9d15515f4483" target="_blank">
-        <img class="d-block img-fluid" src="https://cdn.tnris.org/images/cap_area_ortho_dam_banner_21:9.jpg" alt="StratMap 2019 CapArea Imagery">
-      </a>
-      <div class="carousel-caption">
-        <p>Imagery Preview - StratMap 2019 CapArea Imagery</p>
-      </div>
-    </div>
-    <div class="carousel-item">
       <a href="https://data.tnris.org/collection/2679b514-bb7b-409f-97f3-ee3879f34448" target="_blank">
         <img class="d-block img-fluid" src="https://cdn.tnris.org/images/tx_parcel_data_new_banner_21:9.jpg" alt="StratMap 2019 Texas Statewide Parcel Dataset">
       </a>
       <div class="carousel-caption">
         <p>Data Preview - StratMap 2019 Texas Land Parcels</p>
+      </div>
+    </div>
+    <div class="carousel-item">
+      <a href="https://data.tnris.org" target="_blank">
+        <img class="d-block img-fluid" src="https://cdn.tnris.org/images/forum_adam_dataHub_banner_21:9_wBubble.png" alt="Forum DataHub Adam">
+      </a>
+      <div class="carousel-caption">
+        <p>2019 Texas GIS Forum - TNRIS DataHub Presentation</p>
       </div>
     </div>
     {# <div class="carousel-item">


### PR DESCRIPTION
Refer to issue #280 
-Removed GIS Agenda and Forum Cancellation images
-Re-ordered remaining images

-Added shadow to carousel caption text to make more readable against light backgrounds (issue #260)
