### PR TITLE
Minor updates to maps pages

### DIFF
--- a/content/markdown/research-distribution-center/custom-maps.md
+++ b/content/markdown/research-distribution-center/custom-maps.md
@@ -1,7 +1,7 @@
 ---
 layout: rdc/rdc-sub.njk
 title: Custom Maps
-mainimage: https://cdn.tnris.org/images/custom_banner.jpg
+mainimage: https://cdn.tnris.org/images/custom_maps_banner.jpg
 abstract: From customized contour maps to historical imagery posters of your hometown, we can make the map you’re looking for.
 ---
 
@@ -20,47 +20,58 @@ abstract: From customized contour maps to historical imagery posters of your hom
 
 <p class="lead">Just fill out our <a href="/order-map">order form</a> to start a custom map order. List all available datasets you would like to include in your map then TNRIS Staff will contact you with a quote. You can also send us your own geospatial data to add to any custom map we are creating for you.</p>
 
-<div class="bs-callout bs-callout-info"><strong>Important Note:</strong> Coverage area on all maps must be within Texas and show data from the TNRIS archive.. </div>
+<div class="bs-callout bs-callout-info"><strong>Important Note:</strong> Coverage area on all maps must be within Texas and show data from the TNRIS archive. </div>
 
 ## Examples of Previous Work
 <div class="row">
 
-<div class="col-lg-4">
+<div class="col-lg-6">
 <h3>Fishing Map</h3>
+<div class="card cardRDC">
 <a href="https://cdn.tnris.org/images/custom_fishing_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Custom Fishing Map">
-<img src="https://cdn.tnris.org/images/custom_fishing_map_th.jpg" class="card card-body custom-map-thumb img-fluid" alt="Custom Fishing produced by RDC">
+<img src="https://cdn.tnris.org/images/custom_fishing_map_th.jpg" class="custom-map-thumb img-fluid" alt="Custom Fishing produced by RDC">
 </a>
-
-<p>This map combines Bathymetry, Fish Attractors, Orthoimagery and Transportation datasets for Lake Buchanan.</p>
+  <div class="card-body">
+    <p class="card-text">This map combines Bathymetry, Fish Attractors, Orthoimagery and Transportation datasets for Lake Buchanan.</p>
+  </div>
+</div>
 </div>
 
-<div class="col-lg-4">
+<div class="col-lg-6">
 <h3>Ranch Map</h3>
-
-<a href="https://cdn.tnris.org/images/custom_ranch_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Custom Ranch Map">
-<img src="https://cdn.tnris.org/images/custom_ranch_map_th.jpg" class="card card-body custom-map-thumb img-fluid" alt="Custom Ranch produced by RDC">
+<div class="card cardRDC">
+ <a href="https://cdn.tnris.org/images/custom_ranch_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Custom Ranch Map">
+<img src="https://cdn.tnris.org/images/custom_ranch_map_th.jpg" class="custom-map-thumb img-fluid" alt="Custom Ranch produced by RDC">
 </a>
-
-<p>This ranch map includes data from the Original Texas Land Survey, National Hydrography Dataset, StratMap Hypsography, County Boundaries, Transportation and Elevation Contours.</p>
+  <div class="card-body">
+    <p class="card-text">This ranch map includes data from the Original Texas Land Survey, National Hydrography Dataset, StratMap Hypsography, County Boundaries, Transportation and Elevation Contours.</p>
+  </div>
+</div>
 </div>
 
 
-<div class="col-lg-4">
+<div class="col-lg-6">
 <h3>Custom County Maps</h3>
-<a href="https://cdn.tnris.org/images/galveston_county_custom_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Custom County Map">
-<img src="https://cdn.tnris.org/images/galveston_county_custom_map_th.jpg" class="card card-body custom-map-thumb img-fluid" alt="Custom County produced by RDC">
+<div class="card cardRDC">
+ <a href="https://cdn.tnris.org/images/galveston_county_custom_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Custom County Map">
+<img src="https://cdn.tnris.org/images/galveston.jpg" class="custom-map-thumb img-fluid" alt="Custom County produced by RDC">
 </a>
-<p>The Custom County Map series was developed in-house by TNRIS Cartographers and provides an individual map for all 254 counties. These maps can serve as basic reference maps and base maps. Galveston County is shown above.</p>
+  <div class="card-body">
+    <p class="card-text">The Custom County Map series was developed in-house by TNRIS Cartographers and provides an individual map for all 254 counties. These maps can serve as basic reference maps and base maps. Galveston County is shown above.</p>
+  </div>
+</div>
 </div>
 
-<div class="col-lg-4">
+
+<div class="col-lg-6">
 <h3>Fly Ash Producers</h3>
-<a href="https://cdn.tnris.org/images/flyash_custom_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Map of Fly Ash Producers">
-<img src="https://cdn.tnris.org/images/flyash_custom_map_th.jpg" class="card card-body custom-map-thumb img-fluid" alt="Fly Ash Map Producer Custom map by RDC">
+<div class="card cardRDC">
+ <a href="https://cdn.tnris.org/images/flyash_custom_map.jpg"  data-toggle="lightbox" data-gallery="example-gallery" data-title="Map of Fly Ash Producers">
+<img src="https://cdn.tnris.org/images/flyash_custom_map.jpg" class="custom-map-thumb img-fluid" alt="Fly Ash Map Producer Custom map by RDC">
 </a>
-<p>This map shows the locations of Class F and Class C Fly Ash producing plants in the state of Texas. Fly Ash is a biproduct of coal-fired power plants commonly used to improve the durability of concrete for road construction purposes.</p>
+  <div class="card-body">
+    <p class="card-text">This map shows the locations of Class F and Class C Fly Ash producing plants in the state of Texas. Fly Ash is a biproduct of coal-fired power plants commonly used to improve the durability of concrete for road construction purposes.</p>
+  </div>
 </div>
-
-
-
+</div>
 </div>

--- a/content/markdown/research-distribution-center/historical-imagery-archive.md
+++ b/content/markdown/research-distribution-center/historical-imagery-archive.md
@@ -1,7 +1,7 @@
 ---
 layout: rdc/historic-imagery.njk
 title: Historical Imagery Archive
-mainimage: https://cdn.tnris.org/images/aerial_index_banner.jpg
+mainimage: https://cdn.tnris.org/images/historical_banner.jpg
 abstract: Our archive consists of over 1,000,000 frames with dates as far back as the 1920s.
 ---
 
@@ -16,7 +16,7 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
 <hr>
 <h3>Online Photo Search</h3>
 <p class="lead"> Customers can perform a <strong>cursory</strong> search of the the TNRIS Historic photo archive and submit an order by using the DataHub.</p>
-<a style="width: 50%; margin-bottom: 10px;" class="btn btn-lg btn-tnris btn-block mx-auto d-block" href="https://data.tnris.org/catalog/%7B%22filters%22%3A%7B%22category%22%3A[%22Historic_Imagery%22]%7D%7D"><img style="width: 20px; margin-bottom: 0 !important;" src="https://cdn.tnris.org/images/baseline_view_comfy_white_36dp.png"> Launch DataHub</a>
+<a style="width: 100%; margin-bottom: 10px;" class="btn btn-lg btn-tnris btn-block mx-auto d-block" href="https://data.tnris.org/catalog/%7B%22filters%22%3A%7B%22category%22%3A[%22Historic_Imagery%22]%7D%7D"><img style="width: 20px; margin-bottom: 0 !important;" src="https://cdn.tnris.org/images/baseline_view_comfy_white_36dp.png"> Launch DataHub</a>
 <img src="https://cdn.tnris.org/images/historicphotocatalog.jpg" class="img-fluid rounded" alt="A historical aerial photo is pulled out of a row of other photos">
 </div>
 <div class='col-lg-6'>
@@ -61,9 +61,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
       </a>
       <ul class="list-clean">
           <li><strong>Media Type:</strong> Black and White, Color, and Color Infrared prints</li>
-          <li><strong>General Scales:</strong> 1:3000 – 1:125000</li>
+          <br><li><strong>General Scales:</strong> 1:3000 – 1:125000</li>
           <li>TNRIS houses extensive United States Geological Survey (USGS) collections encompassing the state of Texas.  Dates of collections span from the early 1930s to the late 2000s.</li>
-          <li><strong>About the USGS:</strong><br> The Aerial Photography Single Frame Records collection is a large and diverse group of imagery acquired by federal organizations from 1937 to present.  The USGS, one of the participating federal organizations, houses it’s historical imagery at the USGS Long Term Archive (LTA) at the National Center for Earth Resources Observations and Sciences (EROS) in Sioux Falls, SD.</li>
+          <br><li><strong>About the USGS:</strong> The Aerial Photography Single Frame Records collection is a large and diverse group of imagery acquired by federal organizations from 1937 to present.  The USGS, one of the participating federal organizations, houses it’s historical imagery at the USGS Long Term Archive (LTA) at the National Center for Earth Resources Observations and Sciences (EROS) in Sioux Falls, SD.</li>
       </ul>
   </div>
   <div class="col-lg-6 acquiring-agency">
@@ -73,9 +73,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
       </a>
       <ul class="list-clean">
           <li><strong>Media Type:</strong> Black and White, Color Infrared, Natural Color prints</li>
-          <li><strong>General Scales:</strong> 1:3000</li>
+          <br><li><strong>General Scales:</strong> 1:3000</li>
           <li>TNRIS houses collections from the Texas General Land Office (GLO) from the early 1970s to the 1980s.  The majority of the collections archived at TNRIS are of the Texas coast, neighboring cities and communities, and of mining sites owned by the GLO in west Texas.</li>
-          <li><strong>About the GLO:</strong><br>The GLO was the first Texas public agency established in 1836 responsible for managing lands and mineral rights owned by the state. The agency has historical imagery collections for Texas from the 1930s to present.</li>
+          <br><li><strong>About the GLO:</strong> The GLO was the first Texas public agency established in 1836 responsible for managing lands and mineral rights owned by the state. The agency has historical imagery collections for Texas from the 1930s to present.</li>
       </ul>
   </div>
 </div>
@@ -87,9 +87,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
     </a>
     <ul class="list-clean">
         <li><strong>Media Type:</strong> Black and White prints </li>
-        <li><strong>General Scale: </strong>1:60000</li>
+        <br><li><strong>General Scale: </strong>1:60000</li>
         <li>TNRIS houses extensive Army Map Service (AMS) high altitude collections of Texas from the late 1940s to mid 1950s.</li>
-        <li><strong>About the AMS:</strong><br>The AMS of the U.S. Army Corps of Engineers was the premier map making agency of the U.S. Department of Defense from 1941-1968.  The major task of the AMS was the compilation, publication, and distribution of aerial imagery, military topographic maps, and related products required by the Armed Forces of the United States.</li>
+        <br><li><strong>About the AMS:</strong> The AMS of the U.S. Army Corps of Engineers was the premier map making agency of the U.S. Department of Defense from 1941-1968.  The major task of the AMS was the compilation, publication, and distribution of aerial imagery, military topographic maps, and related products required by the Armed Forces of the United States.</li>
     </ul>
 </div>
 <div class="col-lg-6 acquiring-agency">
@@ -99,9 +99,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
     </a>
     <ul class="list-clean">
         <li><strong>Media Type:</strong> Black and White prints. Line Indexes also available for most counties</li>
-        <li><strong>General scale:</strong> 1:24000</li>
+        <br><li><strong>General scale:</strong> 1:24000</li>
         <li>Texas Department of Transportation's (TXDOT) aerial film archives include high altitude block-area stereo coverage of most of the state's urban counties and some rural areas. The earliest flight was made in 1956. The majority of the urban areas were first flown in the late 1970s and early 1980s.</li>
-        <li><strong>About TxDOT:</strong><br>TxDOT is Texas state agency responsible for construction and maintenance of the state’s immense highway system.  It also oversees aviation, rail, and public transportation systems in the state.  </li>
+       <br><li><strong>About TxDOT:</strong> TxDOT is Texas state agency responsible for construction and maintenance of the state’s immense highway system.  It also oversees aviation, rail, and public transportation systems in the state.  </li>
     </ul>
 </div>
 </div>
@@ -113,9 +113,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
       </a>
       <ul class="list-clean">
           <li><strong>Media Type:</strong> Black and White prints</li>
-          <li><strong>General Scales:</strong> 1:24000</li>
+          <br><li><strong>General Scales:</strong> 1:24000</li>
           <li>TNRIS houses most of Miller’s historical imagery collection in addition to hard copy maps.  The collection is primarily of the central Texas area and covers the mid 1960s through 1990s.</li>
-          <li><strong>About Miller:</strong><br>Miller Imaging and Digital Solutions, previously Miller Blueprint, is a family owned business located in Austin, TX that has been creating photographs, maps, and other printed material for close to a century.</li>
+          <br><li><strong>About Miller:</strong> Miller Imaging and Digital Solutions, previously Miller Blueprint, is a family owned business located in Austin, TX that has been creating photographs, maps, and other printed material for close to a century.</li>
       </ul>
   </div>
   <div class="col-lg-6 acquiring-agency"><h3>United States Air Force</h3>
@@ -124,9 +124,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
       </a>
       <ul class="list-clean">
           <li><strong>Media Type:</strong> Black and White prints</li>
-          <li><strong>General Scale:</strong> 1:56000</li>
+          <br><li><strong>General Scale:</strong> 1:56000</li>
           <li>TNRIS has a small collection of images from the United States Air Force (USAF) spanning the mid 1950s to late 1960s.</li>
-          <li><strong>About the USAF:</strong><br>The Air Force Historical Research Agency, established in 1943, was designated custodian of documents, narratives, reports, orders, and photographs for the Air Force in times of war and peace.  The AFHR serves as a resource for scholars, researchers, government agencies, and the general public.</li>
+          <br><li><strong>About the USAF:</strong> The Air Force Historical Research Agency, established in 1943, was designated custodian of documents, narratives, reports, orders, and photographs for the Air Force in times of war and peace.  The AFHR serves as a resource for scholars, researchers, government agencies, and the general public.</li>
       </ul>
   </div>
 </div>
@@ -138,9 +138,9 @@ abstract: Our archive consists of over 1,000,000 frames with dates as far back a
       </a>
       <ul class="list-clean">
           <li><strong>Media Type:</strong> Black and White, Color Infrared, Natural Color prints.  Line Indexes also available for most counties</li>
-          <li><strong>General Scale:</strong> 1:2000 (ASCS/USDA), 1:60000(NHAP), 1:40000(NAPP)</li>
+          <br><li><strong>General Scale:</strong> 1:2000 (ASCS/USDA), 1:60000(NHAP), 1:40000(NAPP)</li>
           <li>In addition to the United States Department of Agriculture and Agricultural Stabilization and Conservation Service (USDA/ASCS) collections, TNRIS also houses collections from the National High Altitude Program (NHAP) 1980-1989 and the National Aerial Photography Program (NAPP) 1987-2003 both being USGS interagency coordinated programs.</li>
-          <li><strong>About the USDA:</strong><br>The USDA is home to one of the country’s largest aerial film libraries housing more than 10 million images.  Images date back from 1955 to present with coverage of most of the United States and its territories.</li>
+          <br><li><strong>About the USDA:</strong> The USDA is home to one of the country’s largest aerial film libraries housing more than 10 million images.  Images date back from 1955 to present with coverage of most of the United States and its territories.</li>
       </ul>
   </div>
 </div>

--- a/content/markdown/research-distribution-center/index.md
+++ b/content/markdown/research-distribution-center/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rdc/rdc-sub.njk
 title: Research & Distribution Center (RDC)
-mainimage: https://cdn.tnris.org/images/archive_banner.jpg
+mainimage: https://cdn.tnris.org/images/rdc_banner.jpg
 abstract: The Research & Distribution Center (RDC) offers a variety of additional products, support, and services from our in-house staff. We provide hands-on assistance and expertise.
 ---
 

--- a/scss/partials/_rdc.scss
+++ b/scss/partials/_rdc.scss
@@ -10,3 +10,8 @@
       }
     }
 }
+
+.cardRDC {
+  width: 80%;
+  min-height: 90%;
+}

--- a/static/js/maps.js
+++ b/static/js/maps.js
@@ -34,7 +34,7 @@ function buildDownloadsTable(downloads) {
           <th>Width</th>
           <th>Length</th>
           <th>PPI</th>
-          <th>Link</th>
+          <th style="width: 125px;">Link</th>
         </tr>
       </thead>
       <tbody class="map-sheets-tbody">
@@ -58,6 +58,7 @@ function buildCollectionsList(collections) {
   });
   var collectionsList =
   `
+    <br>
     <h4><a href="https://data.tnris.org">DataHub</a> Layers In Map Collection</h4>
     <ul>
       ${listItems}
@@ -99,7 +100,7 @@ function retrieveMaps() {
       var publishDate = new Date(m.publish_date);
       publishDate.setDate(publishDate.getDate()+1);
 
-      var moreInfo = m.more_info_link ? `<a href="${m.more_info_link}" target="_blank" title="Open More Info on ${m.name} in New Window"><i class="fa fa-new-window"></i> More Info</a>` : '';
+      var moreInfo = m.more_info_link ? `<a href="${m.more_info_link}" target="_blank" title="Open More Info on ${m.name} in New Window">More Info <i class="fa fa fa-external-link fa-xs" aria-hidden="true"></i></a>` : '';
       var downloadsList = buildDownloadsTable(m.map_downloads);
       var collectionsList = m.data_collections ? buildCollectionsList(m.data_collections) : '';
 

--- a/templates/rdc/custom-pricing.njk
+++ b/templates/rdc/custom-pricing.njk
@@ -33,13 +33,13 @@
   <ul class="list-nospace">
     <li><strong>FedEx Standard Overnight</strong>
       <ul>
-      <li>24" x 28" or smaller --> $10.00</li>
-      <li>30" x 30" or larger --> $15.00</li>
+      <li>24" x 28" or smaller = $10.00</li>
+      <li>30" x 30" or larger = $15.00</li>
       </ul>
     </li>
     <li><strong>USPS Standard Shipping</strong>
       <ul>
-      <li>All map sizes $5.00</li>
+      <li>All map sizes = $5.00</li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
**Maps**
-“Download Link” column width set to maintain consistency
-FA icon added to “More Info” to signal external link
-line break added above “DataHub Layers in Map Collection”

**RDC Main**
-made banner same height to match others across site

**Historical Imagery**
-made banner same height
-“Launch DataHub” button expanded to take up full width
-line breaks added to “Acquiring Agencies” section for readability

**Custom Maps**
-made banner same height
-pricing “—>” changed to “=“ for consistency
-"Previous Examples" description placed in card body and layout changed to 2x2 to fill white space