### PR TITLE
Mobile responsiveness

### DIFF
--- a/content/markdown/stratmap/land-parcels.md
+++ b/content/markdown/stratmap/land-parcels.md
@@ -102,43 +102,43 @@ youtube_url: https://www.youtube.com/embed/d9Le5oqu4wc
             <li>Planning and early evacuation procedure</li>
           </ul>
         </div>
-        <hr class="clearfix d-none d-sm-none">
-        <div class="row">
-          <div class="col-lg-6">
-            <img src="https://cdn.tnris.org/images/txdot_logo.jpg" class="mx-auto d-block">
-            <p><strong>Texas Department of Transportation (TXDOT)</strong></p>
+      </div>
+      <hr class="clearfix d-none d-sm-none">
+      <div class="row">
+        <div class="col-lg-6">
+          <img src="https://cdn.tnris.org/images/txdot_logo.jpg" class="mx-auto d-block">
+          <p><strong>Texas Department of Transportation (TXDOT)</strong></p>
             <ul>
               <li>Right of Way management for private or state-owned lands</li>
               <li>Transportation planning</li>
             </ul>
-            </p>
-          </div>
-          <div class="col-lg-6">
-            <img src="https://cdn.tnris.org/images/hhs_logo.jpg" class="mx-auto d-block img-fluid">
-            <p><strong>Health and Human Services Commission (HHSC)</strong></p>
-            <ul>
-              <li>Determine structures in the path or vicinity of disease outbreak</li>
-              <li>Analyze economic conditions for services</li>
-            </ul>
-          </div>
+          </p>
         </div>
-        <hr class="clearfix d-none d-sm-none">
-        <div class="row">
-          <div class="col-lg-6">
-            <img src="https://cdn.tnris.org/images/twdb_web_med.jpg" class="mx-auto d-block">
-            <p><strong>Texas Water Development Board (TWDB)</strong></p>
-            <ul>
-              <li>Determine if structures will be affected by flood conditions for early evacuation</li>
-              <li>Determine properties that will be affected with the build of a new dam.</li>
-            </ul>
-          </div>
-          <div class="col-lg-6">
-            <img src="https://cdn.tnris.org/images/tahc_logo.jpg" class="mx-auto d-block">
-            <p><strong>Texas Animal Health Commission (TAHC)</strong></p>
-            <ul>
-              <li>Locate farms, ranches, feedlots, etc in the event of animal disease outbreak</li>
-            </ul>
-          </div>
+        <div class="col-lg-6">
+          <img src="https://cdn.tnris.org/images/hhs_logo.jpg" class="mx-auto d-block img-fluid">
+          <p><strong>Health and Human Services Commission (HHSC)</strong></p>
+          <ul>
+            <li>Determine structures in the path or vicinity of disease outbreak</li>
+            <li>Analyze economic conditions for services</li>
+          </ul>
+        </div>
+      </div>
+      <hr class="clearfix d-none d-sm-none">
+      <div class="row">
+        <div class="col-lg-6">
+          <img src="https://cdn.tnris.org/images/twdb_web_med.jpg" class="mx-auto d-block">
+          <p><strong>Texas Water Development Board (TWDB)</strong></p>
+          <ul>
+            <li>Determine if structures will be affected by flood conditions for early evacuation</li>
+            <li>Determine properties that will be affected with the build of a new dam.</li>
+          </ul>
+        </div>
+        <div class="col-lg-6">
+          <img src="https://cdn.tnris.org/images/tahc_logo.jpg" class="mx-auto d-block">
+          <p><strong>Texas Animal Health Commission (TAHC)</strong></p>
+          <ul>
+            <li>Locate farms, ranches, feedlots, etc in the event of animal disease outbreak</li>
+          </ul>
         </div>
       </div>
       <hr class="clearfix d-none d-sm-none">
@@ -160,7 +160,7 @@ youtube_url: https://www.youtube.com/embed/d9Le5oqu4wc
             <li>Property transactions, planning, and management</li>
             <li>Emergency management and response.</li>
           </ul>
-        </div>
+        </div>  
       </div>
       <hr class="clearfix d-none d-sm-none">
       <div class="row">

--- a/scss/partials/_base.scss
+++ b/scss/partials/_base.scss
@@ -996,3 +996,31 @@ del {
     padding-left: .5rem !important;
   }
 }
+
+// Mobile banner resizing
+@media screen and (max-width: $screen-xs) {
+  .banner-lead {
+    font-size: 1rem;
+  }
+}
+
+@media screen and (max-width: $screen-xs) {
+  .banner-header {
+    font-size: 1.5rem;
+  }
+}
+
+@media screen and (max-width: $screen-xs) {
+  .img-responsive {
+    object-fit: cover;
+    min-height: 200px;
+  }
+}
+
+// Twitter timeline
+@media screen and (max-width: $screen-xs) {
+  .twitter-timeline {
+    width: 90% !important;
+    margin-left: 5%;
+  }
+}

--- a/templates/education/main.njk
+++ b/templates/education/main.njk
@@ -10,14 +10,14 @@
 
         <div class="top-container">
         {% if mainimage %}
-          <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+          <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
         {% endif %}
 
         <div class="top-header mx-auto d-block">
             <div class="container-md">
-              <h1>{{title}}</h1>
+              <h1 class="banner-header">{{title}}</h1>
               {% if abstract %}
-                <div class="lead">{{abstract}}</div>
+                <div class="lead banner-lead">{{abstract}}</div>
               {% endif %}
             </div>
         </div>

--- a/templates/education/teachers.njk
+++ b/templates/education/teachers.njk
@@ -5,14 +5,14 @@
 
         <div class="top-container">
         {% if mainimage %}
-          <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+          <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
         {% endif %}
 
         <div class="top-header mx-auto d-block">
             <div class="container-md">
-              <h1>{{title}}</h1>
+              <h1 class="banner-header">{{title}}</h1>
               {% if abstract %}
-                <div class="lead">{{abstract}}</div>
+                <div class="lead banner-lead">{{abstract}}</div>
               {% endif %}
             </div>
         </div>

--- a/templates/events/events-main.njk
+++ b/templates/events/events-main.njk
@@ -4,12 +4,12 @@
   <div class="container-fluid full">
     <div class="top-container">
       {% if mainimage %}
-        <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+        <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
       {% endif %}
 
       <div class="top-header mx-auto d-block">
         <div class="container-md">
-          <h1>{{title}}</h1>
+          <h1 class="banner-header">{{title}}</h1>
         </div>
       </div>
     </div>

--- a/templates/gio/gio-sub-dcs.njk
+++ b/templates/gio/gio-sub-dcs.njk
@@ -4,12 +4,12 @@
 <div class="container-fluid full gio-top">
   <div class="top-container">
   {% if mainimage %}
-    <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+    <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
   {% endif %}
 
     <div class="top-header mx-auto d-block">
         <div class="container-md">
-          <h1>
+          <h1 class="banner-header">
             <small>Texas Geographic Information Office</small>
             {{title}}
           </h1>

--- a/templates/gio/gio.njk
+++ b/templates/gio/gio.njk
@@ -4,7 +4,7 @@
   <div class="container-fluid full gio-top">
     <div class="top-container">
     {% if mainimage %}
-      <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+      <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
     {% endif %}
     {% if mainimagemd %}
       <img class="img-fluid mx-auto d-block d-lg-none d-sm-none d-none" src="{{mainimagemd}}" alt="Masthead for {{title}}">
@@ -14,7 +14,7 @@
     {% endif %}
     <div class="top-header mx-auto d-block">
         <div class="container-md">
-          <h1>{{title}}</h1>
+          <h1 class="banner-header">{{title}}</h1>
         </div>
     </div>
     </div>

--- a/templates/partials/navbar.njk
+++ b/templates/partials/navbar.njk
@@ -5,7 +5,7 @@
         <span class="d-none d-sr">Texas Natural Resources Information System</span>
       </a>
 
-      <a href="#" class="navbar-toggler navbar-toggler-right d-sm-inline d-md-none" type="button" data-toggle="collapse" data-target="#bs-navbar-collapse" aria-controls="bs-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <a href="#" class="navbar-toggler navbar-toggler-right d-sm-inline d-md-none" data-toggle="collapse" data-target="#bs-navbar-collapse" aria-controls="bs-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="fas fa-bars"></span>
       </a>
       <span class="tnris-name d-none d-md-inline">Texas Natural Resources Information System</span>

--- a/templates/rdc/historic-imagery.njk
+++ b/templates/rdc/historic-imagery.njk
@@ -6,14 +6,14 @@
 
       <div class="top-container">
       {% if mainimage %}
-        <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+        <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
       {% endif %}
 
       <div class="top-header mx-auto d-block">
           <div class="container-md">
-            <h1>{{title}}</h1>
+            <h1 class="banner-header">{{title}}</h1>
             {% if abstract %}
-              <div class="lead">{{abstract}}</div>
+              <div class="lead banner-lead">{{abstract}}</div>
             {% endif %}
           </div>
       </div>

--- a/templates/rdc/rdc-sub.njk
+++ b/templates/rdc/rdc-sub.njk
@@ -6,14 +6,14 @@
 
       <div class="top-container">
       {% if mainimage %}
-        <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+        <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
       {% endif %}
 
       <div class="top-header mx-auto d-block">
           <div class="container-md">
-            <h1>{{title}}</h1>
+            <h1 class="banner-header">{{title}}</h1>
             {% if abstract %}
-              <div class="lead">{{abstract}}</div>
+              <div class="lead banner-lead">{{abstract}}</div>
             {% endif %}
           </div>
       </div>

--- a/templates/stratmap/ap-lp-page.njk
+++ b/templates/stratmap/ap-lp-page.njk
@@ -3,7 +3,7 @@
 {% block topcontent %}
 <div id="stratmap-top-header" class="p-2">
   <div class="container-md">
-    <h1 id="ap-lp-title"><small class="text-muted">StratMap</small><br>{{title}}</h1>
+    <h1 id="ap-lp-title" class="banner-header"><small class="text-muted">StratMap</small><br>{{title}}</h1>
   </div>
 </div>
 <div class="container-fluid full">

--- a/templates/stratmap/main.njk
+++ b/templates/stratmap/main.njk
@@ -5,11 +5,11 @@
 
       <div class="top-container">
       {% if mainimage %}
-        <img class="img-fluid mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
+        <img class="img-fluid img-responsive mx-auto d-block" src="{{mainimage}}" alt="Masthead for {{title}}">
       {% endif %}
       <div class="top-header mx-auto d-block">
           <div class="container-md">
-            <h1>
+            <h1 class="banner-header">
               {% if 'StratMap' in title %}
                 {{title}}
               {% else %}


### PR DESCRIPTION
Refer issue #295 

- Media queries used to apply new classes for mobile devices w/ screen width <480 px. New classes were created to prevent other uses of h1, lead, and img-fluid from being affected across site. 

- .img-responsive fills banner with image (eliminating black bars)

- .banner-header & .banner-lead reduce font-size for h1 and lead text used in banners (prevents text from being cut-off)

- Twitter timeline width slightly reduced for mobile devices to allow more room for scrolling 

- Button behind hamburger menu for Apple mobile devices removed to match Android 




