### PR TITLE
GIO Page - Events

### DIFF
--- a/scss/partials/_gio-page.scss
+++ b/scss/partials/_gio-page.scss
@@ -262,9 +262,8 @@ hr.noMarg {
 .meeting-box {
   background: $lightblue;
   border: 1px solid $tnrisblue;
-  padding: 20px;
+  padding: 0px;
   border-radius: 5px;
-  margin: 0 0 20px 0;
 
   h3 {
     margin-top: 0;
@@ -310,10 +309,10 @@ hr.noMarg {
   border: solid thin #CCC;
   padding: 10px;
   box-shadow: 0 2px 6px #CCC;
-  border-radius: 1%;
+  border-radius: 5px;
   min-height: 100%;
   max-height: 100%;
-  min-width: 230px;
+  min-width: 100%;
 }
 
 h5 {
@@ -336,7 +335,7 @@ h5 {
   padding: 0;
   margin-top: 10px;
   &.event-link {
-    width: 12rem;
+    width: 100%;
     height: auto;
     .circle {
       @include transition(all, 0.45s, cubic-bezier(0.65,0,.076,1));
@@ -382,7 +381,7 @@ h5 {
       right: 0;
       bottom: 0;
       padding: 0.75rem 0;
-      margin: 0 0 0 1.85rem;
+      margin: 0 0 0 1rem;
       color: $tnrisblue;
       font-weight: 600;
       line-height: 1.6;

--- a/scss/partials/_gio-page.scss
+++ b/scss/partials/_gio-page.scss
@@ -260,13 +260,16 @@ hr.noMarg {
 }
 
 .meeting-box {
-  background: $lightblue;
-  border: 1px solid $tnrisblue;
-  padding: 0px;
-  border-radius: 5px;
+  padding: -10px;
+  
+    .eventBox {
+      border: 1px solid $tnrisblue;
+      border-radius: 5px;
+      background: $lightblue;
+    }
 
   h3 {
-    margin-top: 0;
+    margin-top: 15px;
   }
 }
 
@@ -308,7 +311,7 @@ hr.noMarg {
 .eventBox {
   border: solid thin #CCC;
   padding: 10px;
-  box-shadow: 0 2px 6px #CCC;
+  box-shadow: 0 2px 4px #CCC;
   border-radius: 5px;
   min-height: 100%;
   max-height: 100%;

--- a/static/js/gio_calendar_quad.js
+++ b/static/js/gio_calendar_quad.js
@@ -32,6 +32,7 @@ function retrieveNextFourEvents() {
       event.innerHTML =
         `
         <div class="eventBox d-flex flex-column justify-content-between">
+        <div>
           <h3>
             <strong>${e.title}</strong>
             <br>
@@ -40,6 +41,8 @@ function retrieveNextFourEvents() {
           ${e.pretty_date}${communityMeetingStar}
           </h5>
           ${timeRange}
+          <br>
+          </div>
           ${shortDescription}
           ${generalLocation}
           <div class="justify-content-between">

--- a/static/js/gio_calendar_quad.js
+++ b/static/js/gio_calendar_quad.js
@@ -43,8 +43,8 @@ function retrieveNextFourEvents() {
           ${shortDescription}
           ${generalLocation}
           <div class="justify-content-between">
-            ${eventLink}
             ${communityMeetingAgenda}
+            ${eventLink}
           </div>
         </div>
           `;


### PR DESCRIPTION
refer issue #308 

- Updated container width to correct issue with highlighted community meeting boxes overlapping between 992-1200px width
- Moved 'Meeting Agenda' above 'Event Link' to keep 'Event Link' position relatively similar across containers
- Border radius changed to match on standard and highlighted
- 'Event Link' button width changed to span full width (and prevent overlapping)

*If a URL is placed in the location (or other text field) it will still run-over into the next box. However, I'm not sure if this would be an issue since it seems like that should be what the Event Link button is for. 

