### PR TITLE
Education class months (front page)

### DIFF
--- a/templates/education/education-front.njk
+++ b/templates/education/education-front.njk
@@ -10,7 +10,7 @@
     self-paced online courses.
   </p>
   <p>
-    Check out courses January through March on the Education page and register now.
+    Check out courses April through August on the Education page and register now.
   </p>
 
   {# <h3 id="education-front-h3">  #}


### PR DESCRIPTION
Issue #339 

Updated training months on front page under Education column

"Check out courses January through March on the Education page and register now."
updated to:
"Check out courses April through August on the Education page and register now."