### PR TITLE
Stratmap Contracts update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4183,9 +4183,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "hpack.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9611,9 +9611,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "undertaker": {

--- a/templates/stratmap/contract-vendors.njk
+++ b/templates/stratmap/contract-vendors.njk
@@ -36,7 +36,16 @@
       dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4690&keyword=Atlantic',
       tags: ['products','services']
     },
-     {
+    {
+      name: 'Continental Mapping Consultants, Inc.',
+      status: 'available',
+      logo_url: 'https://cdn.tnris.org/images/continental_logo.png',
+      vendor_home_url: 'https://www.continentalmapping.com/',
+      vendor_page_url: '',
+      dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4762&keyword=Continental%20Mapping',
+      tags: ['products','services']
+    },
+    {
       name: 'Dewberry Engineers, Inc.',
       status: 'available',
       logo_url: 'https://cdn.tnris.org/images/Dewberry_web.png',
@@ -44,15 +53,6 @@
       vendor_page_url: 'https://www.dewberry.com/services/geospatial/texas-dir',
       dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4506&keyword=Dewberry',
       tags: ['products','services']
-    },
-    {
-      name: 'Esri',
-      status: 'available',
-      logo_url: 'https://cdn.tnris.org/images/esri_web_md.png',
-      vendor_home_url: 'https://www.esri.com/en-us/home',
-      vendor_page_url: 'http://www.esri.com/landing-pages/texas-dir',
-      dir_page_url: 'http://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-TSO-3446&keyword=3446',
-      tags: ['software']
     },
     {
       name: 'Fugro USA Land, Inc.',
@@ -93,7 +93,7 @@
     {
       name: 'HDR Engineering, Inc.',
       status: 'available',
-      logo_url: 'https://cdn.tnris.org/images/hdr_web.png',
+      logo_url: 'https://cdn.tnris.org/images/HDR_logo.png',
       vendor_home_url: 'https://www.hdrinc.com',
       vendor_page_url: 'https://experience.arcgis.com/experience/4365123019ec42d5949b082ac098b088/',
       dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4694&keyword=HDR',
@@ -104,7 +104,7 @@
       status: 'available',
       logo_url: 'https://cdn.tnris.org/images/KCI_logo_long.png',
       vendor_home_url: 'https://www.kci.com',
-      vendor_page_url: '',
+      vendor_page_url: 'https://texassolutions.kci.com/',
       dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4647&keyword=KCI',
       tags: ['services']
     },
@@ -156,7 +156,7 @@
     {
       name: 'Tessellations Incorporated',
       status: 'available',
-      logo_url: 'https://cdn.tnris.org/images/tesselations_logo.jpg',
+      logo_url: 'https://cdn.tnris.org/images/tessellations_inc.png',
       vendor_home_url: 'https://www.tessellations.us/',
       vendor_page_url: 'https://tessellations.us/texas-dir/',
       dir_page_url: 'https://dir.texas.gov/View-Search/Contracts-Detail.aspx?contractnumber=DIR-CPO-4750&keyword=Tessellations',
@@ -175,7 +175,7 @@
 %}
 
 {% for item in contract_vendors %}
-  <div class="col-lg-2 d-flex align-items-stretch">
+  <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 d-flex align-items-stretch">
     {% if item.status == 'unavailable' %}
     <div class="card card-body vendor-box unavailable">
     {% else %}


### PR DESCRIPTION
issue #356 

- Added Continental Mapping Consultants
- Removed Esri
- Added KCI's contract page 
- Bootstrap columns added for improved responsiveness
- New logos for HDR & Tessellations for more consistent sizing
- Included dependabot update PR #355 "Bump underscore from 1.10.2 to 1.13.1"
- Included dependabot update PR #358 "Bump hosted-git-info from 2.8.8 to 2.8.9"