### PR TITLE
#494 universal edit

### DIFF
--- a/scss/partials/_dataspot.scss
+++ b/scss/partials/_dataspot.scss
@@ -259,7 +259,7 @@
   object-fit: cover;
   width: 100% !important;
   height: 100% !important;
-  max-height: 650px;
+  max-height: 641px;
 
 }
 

--- a/templates/base.njk
+++ b/templates/base.njk
@@ -8,9 +8,6 @@
     {% block title %}
       <title>{% if title %}{{title}} | {% endif %}TxGIO - Texas Geographic Information Office</title>
     {% endblock %}
-    {% block img %}
-      <meta property="og:image" content="{% if mainimage %}{{mainimage}}{% endif %}">
-    {% endblock %}
     {% block styles %}{% include "partials/styles.njk" %}{% endblock %}
   </head>
 

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -4,6 +4,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="shortcut icon" href="/favicon.ico">
 {% if description %}<meta name="description" content="{{description}}">
-{% elseif abstract %}<meta name="description" content="{{abstract}}">
+<meta property="og:description" content="{{description}}">
+{% elseif abstract %}<meta property="og:description" content="{{abstract}}">
 {% endif %}
+{% if mainimage %}<meta property="og:image" content="{{mainimage}}">{% endif %}
 {% if author %}<meta name="author" content="{{author}}">{% endif %}
+{% if title %}<meta property="og:title" content="{{title}} | TxGIO">{% endif %}

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -7,6 +7,9 @@
 <meta property="og:description" content="{{description}}">
 {% elseif abstract %}<meta property="og:description" content="{{abstract}}">
 {% endif %}
-{% if mainimage %}<meta property="og:image" content="{{mainimage}}">{% endif %}
+{% if mainimage %}<meta property="og:image" content="{{mainimage}}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="Texas Geographic Information Office">
+{% endif %}
 {% if author %}<meta name="author" content="{{author}}">{% endif %}
 {% if title %}<meta property="og:title" content="{{title}} | TxGIO">{% endif %}


### PR DESCRIPTION
I looked into a universal fix to the injection of meta tags on the events page, I saw the entire site struggled with this so I went to the files that edited the Head on all pages and try to input it there instead, now any page that has data it will have a better link preview.